### PR TITLE
Component extention

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ export default Ember.Component.extend({
 })
 ```
 
-If this mixin is being used in a class other than Component, it will still need to be mixed into the class:
+If this mixin is being used in a class other than Component, it will need to be mixed into the class:
 
-```
+```js
 import Ember from 'ember'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,31 @@ export default Ember.Component.extend({
 })
 ```
 
+If this mixin is being used in a class other than Component, it will still need to be mixed into the class:
+
+```
+import Ember from 'ember'
+import PropTypeMixin, {PropTypes} from 'ember-prop-types'
+
+export default Ember.ClassName.extend(PropTypeMixin, {
+  propTypes: {
+    foo: PropTypes.string,
+    bar: PropTypes.number.isRequired,
+    baz: PropTypes.oneOf([
+      PropTypes.bool,
+      PropTypes.string
+    ])
+  },
+
+  getDefaultProps () {
+    return {
+      foo: 'This is going to be highly profitable'
+    }
+  }
+})
+```
+
+
 #### Property Validation
 
 The idea of *propTypes* comes from the world of React and is implemented to have an almost identical API in the Ember world. Below is a list of possible *propTypes* to validate against.

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Below is an example of a component that uses the property mixin provided by this
 
 ```js
 import Ember from 'ember'
-import PropTypeMixin, {PropTypes} from 'ember-prop-types'
+import {PropTypes} from 'ember-prop-types'
 
-export default Ember.Component.extend(PropTypeMixin, {
+export default Ember.Component.extend({
   propTypes: {
     foo: PropTypes.string,
     bar: PropTypes.number.isRequired,

--- a/addon/extensions/component-prop-types.js
+++ b/addon/extensions/component-prop-types.js
@@ -1,0 +1,15 @@
+import Ember from 'ember'
+import PropTypeMixin from '../mixins/prop-types'
+
+const {
+  Component
+} = Ember
+
+/**
+ * @module
+ */
+
+/**
+ * @memberof ember/Component#
+ */
+Component.reopen(PropTypeMixin)

--- a/addon/initializers/component-prop-types.js
+++ b/addon/initializers/component-prop-types.js
@@ -1,0 +1,24 @@
+import '../extensions/component-prop-types'
+
+/**
+ * @module
+ */
+
+/**
+ * To load the component-prop-types extensions for Ember.Component
+ *
+ * @function
+ * @returns {undefined}
+*/
+export function initialize () {
+}
+
+/**
+ * Export the addon component-prop-types extensions initializer
+ *
+ * @type {Object}
+ */
+export default {
+  name: 'component-prop-types',
+  initialize
+}

--- a/app/initializers/component-prop-types.js
+++ b/app/initializers/component-prop-types.js
@@ -1,1 +1,1 @@
-export { default, initialize } from 'ember-prop-types/initializers/component-prop-types';
+export { default, initialize } from 'ember-prop-types/initializers/component-prop-types'

--- a/app/initializers/component-prop-types.js
+++ b/app/initializers/component-prop-types.js
@@ -1,0 +1,1 @@
+export { default, initialize } from 'ember-prop-types/initializers/component-prop-types';

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "ember-resolver": "^2.0.3",
     "ember-sinon": "0.5.0",
     "ember-try": "^0.2.0",
-    "eslint": "2.8.0",
+    "eslint": "^2.8.0",
     "eslint-config-frost-standard": "^2.0.0",
     "loader.js": "^4.0.0"
   },

--- a/tests/unit/initializers/component-prop-types-test.js
+++ b/tests/unit/initializers/component-prop-types-test.js
@@ -1,0 +1,39 @@
+/* jshint expr:true */
+import { expect } from 'chai'
+import {
+  describe,
+  it,
+  beforeEach
+} from 'mocha'
+import Ember from 'ember'
+import { initialize } from 'ember-prop-types/initializers/component-prop-types'
+import PropTypesMixin from 'ember-prop-types/mixins/prop-types'
+
+describe('ComponentPropTypesInitializer', function () {
+  let container, application
+
+  beforeEach(function () {
+    Ember.run(function () {
+      application = Ember.Application.create()
+      container = application.__container__
+      application.deferReadiness()
+    })
+  })
+
+  // Replace this with your real tests.
+  it('works', function () {
+    initialize(container, application)
+
+    // you would normally confirm the results of the initializer here
+    expect(true).to.be.ok
+  })
+
+  it('has the expected Mixins', function () {
+    initialize(container, application)
+    const newComponent = Ember.Component.create()
+    expect(
+      PropTypesMixin.detect(newComponent),
+      'PropTypesMixin Mixin is present'
+    ).to.be.true
+  })
+})


### PR DESCRIPTION
#MINOR#

Updated this add-on so that it is no longer necessary to add this mixin to the Component explicitly. The usage for components can now be:

```
import Ember from 'ember'
import {PropTypes} from 'ember-prop-types'

export default Ember.Component.extend({
  propTypes: {
    foo: PropTypes.string,
    bar: PropTypes.number.isRequired,
    baz: PropTypes.oneOf([
      PropTypes.bool,
      PropTypes.string
    ])
  },

  getDefaultProps () {
    return {
      foo: 'This is going to be highly profitable'
    }
  }
})
```

