### PR TITLE
Removing lodash as a dependency

### DIFF
--- a/addon/mixins/prop-types.js
+++ b/addon/mixins/prop-types.js
@@ -1,5 +1,7 @@
-import _ from 'lodash'
 import Ember from 'ember'
+const {
+  typeOf
+} = Ember
 import PropTypes, {validators} from '../utils/prop-types'
 import config from 'ember-get-config'
 
@@ -37,7 +39,9 @@ const helpers = {
       return
     }
 
-    _.forIn(propTypes, (def, name) => {
+    Object.keys(propTypes).forEach(name => {
+      const def = propTypes[name]
+
       if (def === undefined) {
         Ember.Logger.warn(`propType for ${name} is unknown`)
         return
@@ -52,12 +56,19 @@ export default Ember.Mixin.create({
   init () {
     helpers.validatePropTypes(this)
 
-    if (_.isFunction(this.getDefaultProps)) {
+    if (typeOf(this.getDefaultProps) === 'function') {
       const presentPropKeys = Object.keys(this)
       const defaultProps = this.getDefaultProps()
-      const needsSetProps = _.omit(defaultProps, presentPropKeys)
 
-      this.setProperties(needsSetProps)
+      const needsDefaultProp = Object.assign({}, ...(Object.keys(defaultProps).forEach((key) => {
+        if (!presentPropKeys.hasOwnProperty(key)) {
+          return {
+            [key]: defaultProps[key]
+          }
+        }
+      })))
+
+      this.setProperties(needsDefaultProp)
     }
 
     this._super()

--- a/addon/utils/prop-types.js
+++ b/addon/utils/prop-types.js
@@ -1,11 +1,13 @@
-import _ from 'lodash'
 import Ember from 'ember'
+const {
+  typeOf
+} = Ember
 
 const PropTypes = {}
 
 const validators = {
   EmberObject: function (ctx, name, value, def, logErrors) {
-    const valid = Ember.Object.prototype.isPrototypeOf(value)
+    const valid = typeOf(value) === ('instance' || 'class')
 
     if (!valid && logErrors) {
       Ember.Logger.warn(`Expected property ${name} to be an Ember.Object`)
@@ -15,7 +17,7 @@ const validators = {
   },
 
   array: function (ctx, name, value, def, logErrors) {
-    const valid = _.isArray(value)
+    const valid = typeOf(value) === 'array'
 
     if (!valid && logErrors) {
       Ember.Logger.warn(`Expected property ${name} to be an array`)
@@ -25,7 +27,7 @@ const validators = {
   },
 
   bool: function (ctx, name, value, def, logErrors) {
-    const valid = _.isBoolean(value)
+    const valid = typeOf(value) === 'boolean'
 
     if (!valid && logErrors) {
       Ember.Logger.warn(`Expected property ${name} to be a boolean`)
@@ -35,7 +37,7 @@ const validators = {
   },
 
   func: function (ctx, name, value, def, logErrors) {
-    const valid = _.isFunction(value)
+    const valid = typeOf(value) === 'function'
 
     if (!valid && logErrors) {
       Ember.Logger.warn(`Expected property ${name} to be a function`)
@@ -55,7 +57,7 @@ const validators = {
   },
 
   number: function (ctx, name, value, def, logErrors) {
-    const valid = _.isNumber(value)
+    const valid = typeOf(value) === 'number'
 
     if (!valid && logErrors) {
       Ember.Logger.warn(`Expected property ${name} to be a number`)
@@ -65,7 +67,7 @@ const validators = {
   },
 
   object: function (ctx, name, value, def, logErrors) {
-    const valid = _.isPlainObject(value)
+    const valid = typeOf(value) === 'object'
 
     if (!valid && logErrors) {
       Ember.Logger.warn(`Expected property ${name} to be an object`)
@@ -75,7 +77,7 @@ const validators = {
   },
 
   string: function (ctx, name, value, def, logErrors) {
-    const valid = _.isString(value)
+    const valid = typeOf(value) === 'string'
 
     if (!valid && logErrors) {
       Ember.Logger.warn(`Expected property ${name} to be a string`)
@@ -103,7 +105,7 @@ Object.keys(validators).forEach((key) => {
 validators.oneOfType = function (ctx, name, value, def) {
   let valid = false
 
-  if (!_.isArray(def.typeDefs)) {
+  if (typeOf(def.typeDefs) !== 'array') {
     Ember.Logger.warn(
       'PropTypes.oneOfType() requires an array of types to be passed in as an argument'
     )
@@ -131,14 +133,14 @@ validators.oneOfType = function (ctx, name, value, def) {
 validators.oneOf = function (ctx, name, value, def, logErrors) {
   const valueOptions = def.valueOptions
 
-  if (!_.isArray(valueOptions)) {
+  if (typeOf(valueOptions) !== 'array') {
     Ember.Logger.warn(
       'PropTypes.oneOf() requires an array of values to be passed in as an argument'
     )
     return false
   }
 
-  const valid = _.some(valueOptions, (option) => option === value)
+  const valid = valueOptions.some((option) => option === value)
 
   if (!valid && logErrors) {
     Ember.Logger.warn(`Property ${name} is not one of ${valueOptions.join(', ')}`)
@@ -160,14 +162,14 @@ validators.instanceOf = function (ctx, name, value, def, logErrors) {
 
 validators.shape = function (ctx, name, value, def, logErrors) {
   const typeDefs = def.typeDefs
-  if (!_.isPlainObject(typeDefs)) {
+  if (typeOf(typeDefs) !== 'object') {
     Ember.logger.warn(
       'PropTypes.shape() requires a plain object to be be passed in as an argument'
     )
     return false
   }
 
-  const valid = _.every(Object.keys(typeDefs), (key) => {
+  const valid = Object.keys(typeDefs).every((key) => {
     const typeDef = typeDefs[key]
     const objectValue = Ember.get(value, key)
     return validators[typeDef.type](ctx, key, objectValue, typeDef, false)

--- a/package.json
+++ b/package.json
@@ -35,14 +35,12 @@
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
     "ember-load-initializers": "^0.5.0",
-    "ember-lodash-shim": "0.1.0",
     "ember-resolver": "^2.0.3",
     "ember-sinon": "0.5.1",
     "ember-try": "^0.2.0",
     "eslint": "3.2.2",
     "eslint-config-frost-standard": "^3.0.0",
-    "loader.js": "^4.0.0",
-    "lodash-es": "4.14.1"
+    "loader.js": "^4.0.0"
   },
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
#feature#

# CHANGELOG

- Removed lodash as a dependency to avoid lodash as a downstream requirement
- Replaced lodash functions with equivalent Ember/ES6/custom functions