### PR TITLE
Fix shape with non-required props to resolve #24

### DIFF
--- a/addon/utils/validators/shape.js
+++ b/addon/utils/validators/shape.js
@@ -10,10 +10,24 @@ export default function (validators, ctx, name, value, def, logErrors) {
     return false
   }
 
-  const valid = Object.keys(typeDefs).every((key) => {
+  if (typeOf(value) !== 'object') {
+    Logger.warn(`Property ${name} does not match the given shape`)
+    return false
+  }
+
+  let valid = Object.keys(typeDefs).every((key) => {
     const typeDef = typeDefs[key]
+
+    if (!typeDef.required && value[key] === undefined) {
+      return true
+    }
+
     const objectValue = Ember.get(value, key)
     return validators[typeDef.type](ctx, key, objectValue, typeDef, false)
+  })
+
+  valid = valid && Object.keys(value).every((key) => {
+    return key in typeDefs
   })
 
   if (!valid && logErrors) {

--- a/tests/unit/prop-types/shape-test.js
+++ b/tests/unit/prop-types/shape-test.js
@@ -226,11 +226,9 @@ describe('PropTypes.shape', function () {
         expect(helpers.validateProperty.lastCall.args).to.eql([instance, 'bar', def])
       })
 
-      /* FIXME: Issue #24
       it('does not log warning', function () {
         expect(Logger.warn.callCount).to.equal(0)
       })
-      */
     })
 
     describe('when initialized with incorrect shape value', function () {
@@ -252,7 +250,7 @@ describe('PropTypes.shape', function () {
         expect(helpers.validateProperty.lastCall.args).to.eql([instance, 'bar', def])
       })
 
-      it('does not log warning', function () {
+      it('logs warning', function () {
         expect(Logger.warn.callCount).to.equal(1)
         expect(Logger.warn.lastCall.args).to.eql(['Property bar does not match the given shape'])
       })
@@ -532,11 +530,9 @@ describe('PropTypes.shape', function () {
         expect(helpers.validateProperty.lastCall.args).to.eql([instance, 'bar', def])
       })
 
-      /* FIXME: Issue #24
       it('does not log warning', function () {
         expect(Logger.warn.callCount).to.equal(0)
       })
-      */
     })
 
     describe('when initialized with incorrect shape value', function () {


### PR DESCRIPTION
#PATCH#

# CHANGELOG

* **Fixed** `shape` prop-type to not error when non-required props in shape are not present.