### PR TITLE
Use Object.assign if no Ember.assign. And Ember.merge if no Object.assign

### DIFF
--- a/addon/utils/validators/index.js
+++ b/addon/utils/validators/index.js
@@ -1,6 +1,6 @@
 import Ember from 'ember'
-const {assign} = Ember
 
+const assign = Ember.assign || Object.assign || Ember.merge
 import any from './any'
 import array from './array'
 import arrayOf from './array-of'


### PR DESCRIPTION
#PATCH#

Fixes https://github.com/ciena-blueplanet/ember-prop-types/issues/47

# CHANGELOG

* **Fixed** issue when `Ember.assign` does not exist to fallback on `Object.assign` then `Ember.merge`.