### PR TITLE
remove polyfill

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -3,6 +3,10 @@ var EmberAddon = require('ember-cli/lib/broccoli/ember-addon')
 
 module.exports = function (defaults) {
   var app = new EmberAddon(defaults, {
+    'babel': {
+      optional: ['es6.spec.symbols'],
+      includePolyfill: true
+    },
     'ember-cli-mocha': {
       useLintTree: false
     }

--- a/index.js
+++ b/index.js
@@ -1,19 +1,5 @@
 'use strict'
 
 module.exports = {
-  name: 'ember-prop-types',
-
-  init () {
-    this.options = this.options || {}
-    this.options.babel = this.options.babel || {}
-    this.options.babel.optional = this.options.babel.optional || []
-
-    if (this.options.babel.optional.indexOf('es6.spec.symbols') === -1) {
-      this.options.babel.optional.push('es6.spec.symbols')
-    }
-
-    this.options.babel.includePolyfill = true
-
-    this._super.init && this._super.init.apply(this, arguments)
-  }
+  name: 'ember-prop-types'
 }


### PR DESCRIPTION
#PATCH#

All tests pass locally without this. Would love to not include the polyfill if possible.

# CHANGELOG

* Only import polyfill for CI and not for consuming apps. Apps that want Symbol can pay as they go.