### PR TITLE
Fix bug in array-of when used with shape

### DIFF
--- a/addon/utils/validators/array-of.js
+++ b/addon/utils/validators/array-of.js
@@ -5,14 +5,14 @@ import * as logger from '../logger'
 const {isArray} = Array
 
 export default function (validators, ctx, name, value, def, logErrors) {
-  const type = def.typeDef.type
+  const typeDef = def.typeDef
 
   const valid = isArray(value) && value.every((item) => {
-    return validators[type](ctx, name, item, type, false)
+    return validators[typeDef.type](ctx, name, item, typeDef, false)
   })
 
   if (!valid && logErrors) {
-    logger.warn(ctx, `Expected property ${name} to be an array of type ${type}`)
+    logger.warn(ctx, `Expected property ${name} to be an array of type ${typeDef.type}`)
   }
 
   return valid

--- a/tests/helpers/validator.js
+++ b/tests/helpers/validator.js
@@ -18,9 +18,9 @@ import {helpers} from 'ember-prop-types/mixins/prop-types'
  * @param {Object} ctx.def - the propType definition
  * @param {Object} ctx.instance - the object instance that has the mixin
  * @param {String} ctx.propertyName - the object instance that has the mixin
- * @param {String} [warningMessage] - if present, expect Logger.warn to be called with it, else expect no warnings
+ * @param {String[]} [warningMessages] - if present, expect Logger.warn to be called with them, else expect no warnings
  */
-export function itValidatesTheProperty (ctx, warningMessage) {
+export function itValidatesTheProperty (ctx, ...warningMessages) {
   let def, instance, propertyName
 
   beforeEach(function () {
@@ -37,10 +37,12 @@ export function itValidatesTheProperty (ctx, warningMessage) {
     expect(helpers.validateProperty).to.have.been.calledWith(instance, propertyName, def)
   })
 
-  if (warningMessage) {
-    it('should log a warning', function () {
-      expect(Logger.warn).to.have.callCount(1)
-      expect(Logger.warn).to.have.been.calledWith(`[${instance.toString()}]: ${warningMessage}`)
+  if (warningMessages.length > 0) {
+    it('should log warning(s)', function () {
+      expect(Logger.warn).to.have.callCount(warningMessages.length)
+      warningMessages.forEach((msg) => {
+        expect(Logger.warn).to.have.been.calledWith(`[${instance.toString()}]: ${msg}`)
+      })
     })
   } else {
     it('should not log warning', function () {

--- a/tests/unit/prop-types/array-of-test.js
+++ b/tests/unit/prop-types/array-of-test.js
@@ -30,6 +30,43 @@ const notRequiredDef = {
   typeDef: stringTypeDef
 }
 
+const shapeTypeDefs = {
+  fizz: {
+    isRequired: { required: true, type: 'string' },
+    required: false,
+    type: 'string'
+  },
+  bang: {
+    isRequired: { required: true, type: 'number' },
+    required: false,
+    type: 'number'
+  }
+}
+
+const shapeTypeDef = {
+  isRequired: {
+    required: true,
+    type: 'shape',
+    typeDefs: shapeTypeDefs
+  },
+  required: false,
+  type: 'shape',
+  typeDefs: shapeTypeDefs
+}
+
+const requiredShapeDef = {
+  required: true,
+  type: 'arrayOf',
+  typeDef: shapeTypeDef
+}
+
+const notRequiredShapeDef = {
+  isRequired: requiredShapeDef,
+  required: false,
+  type: 'arrayOf',
+  typeDef: shapeTypeDef
+}
+
 describe('Unit / validator / PropTypes.arrayOf', function () {
   const ctx = {propertyName: 'bar'}
   let sandbox, Foo
@@ -119,6 +156,100 @@ describe('Unit / validator / PropTypes.arrayOf', function () {
         })
 
         itValidatesTheProperty(ctx, 'Expected property bar to be an array of type string')
+      })
+
+      describe('when initialized without value', function () {
+        beforeEach(function () {
+          ctx.instance = Foo.create()
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+    })
+  })
+
+  describe('when an array of a complex type (shape)', function () {
+    describe('when required', function () {
+      beforeEach(function () {
+        ctx.def = requiredShapeDef
+        Foo = Ember.Object.extend(PropTypesMixin, {
+          propTypes: {
+            bar: PropTypes.arrayOf(PropTypes.shape({
+              fizz: PropTypes.string,
+              bang: PropTypes.number
+            })).isRequired
+          }
+        })
+      })
+
+      describe('when initialized with array of valid shapes', function () {
+        beforeEach(function () {
+          ctx.instance = Foo.create({bar: [{fizz: 'alpha', bang: 1}, {fizz: 'bravo', bang: 2}]})
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when initialized with array of invalid shapes', function () {
+        beforeEach(function () {
+          ctx.instance = Foo.create({bar: [{foo: 'alpha'}, {bar: 2}]})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an array of type shape')
+      })
+
+      describe('when initialized with a some valid some invalid shapes', function () {
+        beforeEach(function () {
+          ctx.instance = Foo.create({bar: [{fizz: 'alpha', bang: 1}, {foo: 'bar'}]})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an array of type shape')
+      })
+
+      describe('when initialized without value', function () {
+        beforeEach(function () {
+          ctx.instance = Foo.create()
+        })
+
+        itValidatesTheProperty(ctx, 'Missing required property bar')
+      })
+    })
+
+    describe('when not required', function () {
+      beforeEach(function () {
+        ctx.def = notRequiredShapeDef
+        Foo = Ember.Object.extend(PropTypesMixin, {
+          propTypes: {
+            bar: PropTypes.arrayOf(PropTypes.shape({
+              fizz: PropTypes.string,
+              bang: PropTypes.number
+            }))
+          }
+        })
+      })
+
+      describe('when initialized with array of valid shapes', function () {
+        beforeEach(function () {
+          ctx.instance = Foo.create({bar: [{fizz: 'alpha', bang: 1}, {fizz: 'bravo', bang: 2}]})
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when initialized with array of invalid shapes', function () {
+        beforeEach(function () {
+          ctx.instance = Foo.create({bar: [{foo: 'alpha'}, {bar: 2}]})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an array of type shape')
+      })
+
+      describe('when initialized with a some valid some invalid shapes', function () {
+        beforeEach(function () {
+          ctx.instance = Foo.create({bar: [{fizz: 'alpha', bang: 1}, {foo: 'bar'}]})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an array of type shape')
       })
 
       describe('when initialized without value', function () {


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** a bug in the `PropTypes.arrayOf` validator when used in conjunction with the `PropTypes.shape` validator. 

