### PR TITLE
More detailed msgs for PropTypes.{shape,arrayOf)

### DIFF
--- a/addon/utils/validators/array-of.js
+++ b/addon/utils/validators/array-of.js
@@ -7,8 +7,8 @@ const {isArray} = Array
 export default function (validators, ctx, name, value, def, logErrors) {
   const typeDef = def.typeDef
 
-  const valid = isArray(value) && value.every((item) => {
-    return validators[typeDef.type](ctx, name, item, typeDef, false)
+  const valid = isArray(value) && value.every((item, index) => {
+    return validators[typeDef.type](ctx, `${name}[${index}]`, item, typeDef, logErrors)
   })
 
   if (!valid && logErrors) {

--- a/tests/unit/prop-types/array-of-test.js
+++ b/tests/unit/prop-types/array-of-test.js
@@ -104,7 +104,11 @@ describe('Unit / validator / PropTypes.arrayOf', function () {
           ctx.instance = Foo.create({bar: [true, false]})
         })
 
-        itValidatesTheProperty(ctx, 'Expected property bar to be an array of type string')
+        itValidatesTheProperty(
+          ctx,
+          'Expected property bar[0] to be a string',
+          'Expected property bar to be an array of type string'
+        )
       })
 
       describe('when initialized with a heterogenous array', function () {
@@ -112,7 +116,11 @@ describe('Unit / validator / PropTypes.arrayOf', function () {
           ctx.instance = Foo.create({bar: ['alpha', false]})
         })
 
-        itValidatesTheProperty(ctx, 'Expected property bar to be an array of type string')
+        itValidatesTheProperty(
+          ctx,
+          'Expected property bar[1] to be a string',
+          'Expected property bar to be an array of type string'
+        )
       })
 
       describe('when initialized without value', function () {
@@ -147,7 +155,11 @@ describe('Unit / validator / PropTypes.arrayOf', function () {
           ctx.instance = Foo.create({bar: [true, false]})
         })
 
-        itValidatesTheProperty(ctx, 'Expected property bar to be an array of type string')
+        itValidatesTheProperty(
+          ctx,
+          'Expected property bar[0] to be a string',
+          'Expected property bar to be an array of type string'
+        )
       })
 
       describe('when initialized with a heterogenous array', function () {
@@ -155,7 +167,11 @@ describe('Unit / validator / PropTypes.arrayOf', function () {
           ctx.instance = Foo.create({bar: ['alpha', false]})
         })
 
-        itValidatesTheProperty(ctx, 'Expected property bar to be an array of type string')
+        itValidatesTheProperty(
+          ctx,
+          'Expected property bar[1] to be a string',
+          'Expected property bar to be an array of type string'
+        )
       })
 
       describe('when initialized without value', function () {
@@ -195,7 +211,12 @@ describe('Unit / validator / PropTypes.arrayOf', function () {
           ctx.instance = Foo.create({bar: [{foo: 'alpha'}, {bar: 2}]})
         })
 
-        itValidatesTheProperty(ctx, 'Expected property bar to be an array of type shape')
+        itValidatesTheProperty(
+          ctx,
+          'Property bar[0] has an unknown key: foo',
+          'Property bar[0] does not match the given shape',
+          'Expected property bar to be an array of type shape'
+        )
       })
 
       describe('when initialized with a some valid some invalid shapes', function () {
@@ -203,7 +224,12 @@ describe('Unit / validator / PropTypes.arrayOf', function () {
           ctx.instance = Foo.create({bar: [{fizz: 'alpha', bang: 1}, {foo: 'bar'}]})
         })
 
-        itValidatesTheProperty(ctx, 'Expected property bar to be an array of type shape')
+        itValidatesTheProperty(
+          ctx,
+          'Property bar[1] has an unknown key: foo',
+          'Property bar[1] does not match the given shape',
+          'Expected property bar to be an array of type shape'
+        )
       })
 
       describe('when initialized without value', function () {
@@ -241,7 +267,12 @@ describe('Unit / validator / PropTypes.arrayOf', function () {
           ctx.instance = Foo.create({bar: [{foo: 'alpha'}, {bar: 2}]})
         })
 
-        itValidatesTheProperty(ctx, 'Expected property bar to be an array of type shape')
+        itValidatesTheProperty(
+          ctx,
+          'Property bar[0] has an unknown key: foo',
+          'Property bar[0] does not match the given shape',
+          'Expected property bar to be an array of type shape'
+        )
       })
 
       describe('when initialized with a some valid some invalid shapes', function () {
@@ -249,7 +280,12 @@ describe('Unit / validator / PropTypes.arrayOf', function () {
           ctx.instance = Foo.create({bar: [{fizz: 'alpha', bang: 1}, {foo: 'bar'}]})
         })
 
-        itValidatesTheProperty(ctx, 'Expected property bar to be an array of type shape')
+        itValidatesTheProperty(
+          ctx,
+          'Property bar[1] has an unknown key: foo',
+          'Property bar[1] does not match the given shape',
+          'Expected property bar to be an array of type shape'
+        )
       })
 
       describe('when initialized without value', function () {

--- a/tests/unit/prop-types/shape-test.js
+++ b/tests/unit/prop-types/shape-test.js
@@ -62,19 +62,44 @@ describe('Unit / validator / PropTypes.shape', function () {
         })
       })
 
-      itValidatesTheProperty(ctx, 'Property bar does not match the given shape')
+      itValidatesTheProperty(
+        ctx,
+        'Property bar is missing required property baz',
+        'Property bar does not match the given shape'
+      )
     })
 
     describe('when initialized with incorrect shape value', function () {
       beforeEach(function () {
         ctx.instance = Foo.create({
           bar: {
-            spam: 'test'
+            baz: 1
           }
         })
       })
 
-      itValidatesTheProperty(ctx, 'Property bar does not match the given shape')
+      itValidatesTheProperty(
+        ctx,
+        'Expected property bar.baz to be a string',
+        'Property bar does not match the given shape'
+      )
+    })
+
+    describe('when initialized with an extra property in shape', function () {
+      beforeEach(function () {
+        ctx.instance = Foo.create({
+          bar: {
+            baz: 'test',
+            spam: 'is yummy'
+          }
+        })
+      })
+
+      itValidatesTheProperty(
+        ctx,
+        'Property bar has an unknown key: spam',
+        'Property bar does not match the given shape'
+      )
     })
 
     describe('when initialized with number value', function () {
@@ -146,12 +171,32 @@ describe('Unit / validator / PropTypes.shape', function () {
       beforeEach(function () {
         ctx.instance = Foo.create({
           bar: {
+            baz: 1
+          }
+        })
+      })
+
+      itValidatesTheProperty(
+        ctx,
+        'Expected property bar.baz to be a string',
+        'Property bar does not match the given shape'
+      )
+    })
+
+    describe('when initialized with an extra property in the shape', function () {
+      beforeEach(function () {
+        ctx.instance = Foo.create({
+          bar: {
             spam: 'test'
           }
         })
       })
 
-      itValidatesTheProperty(ctx, 'Property bar does not match the given shape')
+      itValidatesTheProperty(
+        ctx,
+        'Property bar has an unknown key: spam',
+        'Property bar does not match the given shape'
+      )
     })
 
     describe('when initialized with number value', function () {
@@ -222,19 +267,44 @@ describe('Unit / validator / PropTypes.shape', function () {
         })
       })
 
-      itValidatesTheProperty(ctx, 'Property bar does not match the given shape')
+      itValidatesTheProperty(
+        ctx,
+        'Property bar is missing required property baz',
+        'Property bar does not match the given shape'
+      )
     })
 
     describe('when initialized with incorrect shape value', function () {
       beforeEach(function () {
         ctx.instance = Foo.create({
           bar: {
-            spam: 'test'
+            baz: 1
           }
         })
       })
 
-      itValidatesTheProperty(ctx, 'Property bar does not match the given shape')
+      itValidatesTheProperty(
+        ctx,
+        'Expected property bar.baz to be a string',
+        'Property bar does not match the given shape'
+      )
+    })
+
+    describe('when initialized with an extra property in the shape', function () {
+      beforeEach(function () {
+        ctx.instance = Foo.create({
+          bar: {
+            baz: 'test',
+            spam: 'is yummy'
+          }
+        })
+      })
+
+      itValidatesTheProperty(
+        ctx,
+        'Property bar has an unknown key: spam',
+        'Property bar does not match the given shape'
+      )
     })
 
     describe('when initialized with number value', function () {
@@ -320,12 +390,33 @@ describe('Unit / validator / PropTypes.shape', function () {
       beforeEach(function () {
         ctx.instance = Foo.create({
           bar: {
-            spam: 'test'
+            baz: 1
           }
         })
       })
 
-      itValidatesTheProperty(ctx, 'Property bar does not match the given shape')
+      itValidatesTheProperty(
+        ctx,
+        'Expected property bar.baz to be a string',
+        'Property bar does not match the given shape'
+      )
+    })
+
+    describe('when initialized with an extra property in the shape', function () {
+      beforeEach(function () {
+        ctx.instance = Foo.create({
+          bar: {
+            baz: 'test',
+            spam: 'is yummy'
+          }
+        })
+      })
+
+      itValidatesTheProperty(
+        ctx,
+        'Property bar has an unknown key: spam',
+        'Property bar does not match the given shape'
+      )
     })
 
     describe('when initialized with number value', function () {


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Added** more detailed messaging for sub-property validations when using `PropTypes.arrayOf` or `PropTypes.shape`