### PR TITLE
Apply defaults when passed in value is undefined

### DIFF
--- a/addon/mixins/prop-types.js
+++ b/addon/mixins/prop-types.js
@@ -74,7 +74,9 @@ export default Ember.Mixin.create({
 
       const defaultProps = propsFunction.apply(this)
       keys.forEach((key) => {
-        delete defaultProps[key]
+        if (this.get(key) !== undefined) {
+          delete defaultProps[key]
+        }
       })
 
       this.setProperties(defaultProps)

--- a/tests/unit/mixins/prop-types-test.js
+++ b/tests/unit/mixins/prop-types-test.js
@@ -342,4 +342,28 @@ describe('Unit / Mixins / prop-types', function () {
       expect(instance.get('quux')).to.equal('!quux')
     })
   })
+
+  describe('applies defaults when user set value is undefined', function () {
+    let instance
+
+    beforeEach(function () {
+      sandbox.spy(helpers, 'validateProperty')
+
+      const MyObject = Ember.Object.extend(PropTypesMixin, {
+        getDefaultProps () {
+          return {
+            foo: 'bar'
+          }
+        }
+      })
+
+      instance = MyObject.create({
+        foo: undefined
+      })
+    })
+
+    it('should set defaults for each property', function () {
+      expect(instance.get('foo')).to.equal('bar')
+    })
+  })
 })


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** bug where defaults weren't being applied when consumer passes in `undefined` for a property with defaults.
