### PR TITLE
Validate spec'd properties on update

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,16 @@
 {
-  "extends": ["frost-standard"]
+  "extends": ["frost-standard"],
+  "rules": {
+    "ocd/sort-import-declarations": [
+      2,
+      {
+        "localPrefixes": [
+          "../",
+          "./",
+          "dummy/",
+          "ember-prop-types/"
+        ]
+      }
+    ]
+  }
 }

--- a/addon/extensions/component-prop-types.js
+++ b/addon/extensions/component-prop-types.js
@@ -1,9 +1,7 @@
 import Ember from 'ember'
-import PropTypeMixin from '../mixins/prop-types'
+const {Component} = Ember
 
-const {
-  Component
-} = Ember
+import PropTypeMixin from '../mixins/prop-types'
 
 /**
  * @module

--- a/addon/mixins/prop-types.js
+++ b/addon/mixins/prop-types.js
@@ -2,9 +2,10 @@
  * The PropTypesMixin definition
  */
 import Ember from 'ember'
-const {typeOf} = Ember
-import PropTypes, {logger, validators} from '../utils/prop-types'
+const {Mixin, typeOf} = Ember
 import config from 'ember-get-config'
+
+import PropTypes, {logger, validators} from '../utils/prop-types'
 
 const helpers = {
   /* eslint-disable complexity */
@@ -54,7 +55,7 @@ const helpers = {
   }
 }
 
-export default Ember.Mixin.create({
+export default Mixin.create({
   concatenatedProperties: ['propTypes', 'getDefaultProps'],
 
   getDefaultProps () {

--- a/addon/mixins/prop-types.js
+++ b/addon/mixins/prop-types.js
@@ -49,6 +49,10 @@ const helpers = {
           return
         }
 
+        ctx.addObserver(name, ctx, function () {
+          helpers.validateProperty(this, name, def)
+        })
+
         helpers.validateProperty(ctx, name, def)
       })
     })

--- a/addon/mixins/prop-types.js
+++ b/addon/mixins/prop-types.js
@@ -2,7 +2,7 @@
  * The PropTypesMixin definition
  */
 import Ember from 'ember'
-const {Mixin, typeOf} = Ember
+const {Mixin, getWithDefault, typeOf} = Ember
 import config from 'ember-get-config'
 
 import PropTypes, {logger, validators} from '../utils/prop-types'
@@ -49,9 +49,11 @@ const helpers = {
           return
         }
 
-        ctx.addObserver(name, ctx, function () {
-          helpers.validateProperty(this, name, def)
-        })
+        if (getWithDefault(config, 'ember-prop-types.validateOnUpdate', false)) {
+          ctx.addObserver(name, ctx, function () {
+            helpers.validateProperty(this, name, def)
+          })
+        }
 
         helpers.validateProperty(ctx, name, def)
       })

--- a/addon/utils/validators/index.js
+++ b/addon/utils/validators/index.js
@@ -1,6 +1,5 @@
-import Ember from 'ember'
+import Ember from 'ember' // eslint-disable-line
 
-const assign = Ember.assign || Object.assign || Ember.merge
 import any from './any'
 import array from './array'
 import arrayOf from './array-of'
@@ -17,6 +16,8 @@ import oneOfType from './one-of-type'
 import shape from './shape'
 import string from './string'
 import symbol from './symbol'
+
+const assign = Object.assign || Ember.assign || Ember.merge // eslint-disable-line
 
 const validators = {
   any,

--- a/addon/utils/validators/shape.js
+++ b/addon/utils/validators/shape.js
@@ -3,7 +3,7 @@
  */
 
 import Ember from 'ember'
-const {typeOf} = Ember
+const {get, typeOf} = Ember
 
 import * as logger from '../logger'
 
@@ -22,7 +22,7 @@ export default function (validators, ctx, name, value, def, logErrors) {
   let valid = Object.keys(typeDefs).every((key) => {
     const typeDef = typeDefs[key]
 
-    const objectValue = Ember.get(value, key)
+    const objectValue = get(value, key)
     if (objectValue === undefined) {
       if (!typeDef.required) {
         return true

--- a/app/initializers/component-prop-types.js
+++ b/app/initializers/component-prop-types.js
@@ -1,1 +1,1 @@
-export { default, initialize } from 'ember-prop-types/initializers/component-prop-types'
+export {default, initialize} from 'ember-prop-types/initializers/component-prop-types'

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "ember-resolver": "^2.0.3",
     "ember-sinon": "^0.6.0",
     "eslint": "^3.4.0",
-    "eslint-config-frost-standard": "^5.0.0",
+    "eslint-config-frost-standard": "^5.3.2",
     "loader.js": "^4.0.0"
   },
   "keywords": [

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -1,13 +1,15 @@
 import Ember from 'ember'
-import Resolver from './resolver'
+const {Application} = Ember
 import loadInitializers from 'ember-load-initializers'
+
 import config from './config/environment'
+import Resolver from './resolver'
 
 let App
 
 Ember.MODEL_FACTORY_INJECTIONS = true
 
-App = Ember.Application.extend({
+App = Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,
   Resolver

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -1,7 +1,9 @@
 import Ember from 'ember'
+const {Router: EmberRouter} = Ember
+
 import config from './config/environment'
 
-const Router = Ember.Router.extend({
+const Router = EmberRouter.extend({
   location: config.locationType
 })
 

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -1,5 +1,6 @@
 import Ember from 'ember'
 const {Route} = Ember
+
 import contributors from '../fixtures/contributors'
 import validators from '../fixtures/validators'
 

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -10,7 +10,11 @@ module.exports = function (environment) {
     ],
     environment: environment,
     locationType: 'auto',
-    modulePrefix: 'dummy'
+    modulePrefix: 'dummy',
+
+    'ember-prop-types': {
+      validateOnUpdate: true
+    }
   }
 
   switch (environment) {

--- a/tests/helpers/destroy-app.js
+++ b/tests/helpers/destroy-app.js
@@ -1,5 +1,6 @@
 import Ember from 'ember'
+const {run} = Ember
 
 export default function destroyApp (application) {
-  Ember.run(application, 'destroy')
+  run(application, 'destroy')
 }

--- a/tests/helpers/resolver.js
+++ b/tests/helpers/resolver.js
@@ -1,5 +1,5 @@
-import Resolver from '../../resolver'
 import config from '../../config/environment'
+import Resolver from '../../resolver'
 
 const resolver = Resolver.create()
 

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -1,14 +1,16 @@
 import Ember from 'ember'
+const {merge, run} = Ember
+
 import Application from '../../app'
 import config from '../../config/environment'
 
 export default function startApp (attrs) {
   let application
 
-  let attributes = Ember.merge({}, config.APP)
-  attributes = Ember.merge(attributes, attrs) // use defaults, but you can override;
+  let attributes = merge({}, config.APP)
+  attributes = merge(attributes, attrs) // use defaults, but you can override;
 
-  Ember.run(() => {
+  run(() => {
     application = Application.create(attributes)
     application.setupForTesting()
     application.injectTestHelpers()

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,4 +1,5 @@
+import {setResolver} from 'ember-mocha'
+
 import resolver from './helpers/resolver'
-import { setResolver } from 'ember-mocha'
 
 setResolver(resolver)

--- a/tests/unit/mixins/prop-types-test.js
+++ b/tests/unit/mixins/prop-types-test.js
@@ -7,7 +7,7 @@ const {Component, Logger, Mixin} = Ember
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
 
-import PropTypesMixin, {helpers, PropTypes} from 'ember-prop-types/mixins/prop-types'
+import PropTypesMixin, {PropTypes, helpers} from 'ember-prop-types/mixins/prop-types'
 
 describe('Unit / Mixins / prop-types', function () {
   let sandbox

--- a/tests/unit/prop-types/any-test.js
+++ b/tests/unit/prop-types/any-test.js
@@ -2,6 +2,7 @@
  * Unit test for the PropTypes.any validator
  */
 import Ember from 'ember'
+const {Logger} = Ember
 import {afterEach, beforeEach, describe} from 'mocha'
 import sinon from 'sinon'
 
@@ -49,6 +50,60 @@ describe('Unit / validator / PropTypes.any', function () {
       })
 
       itValidatesTheProperty(ctx)
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'baz')
+        })
+
+        itValidatesTheProperty(ctx)
+      })
     })
 
     describe('when initialized with boolean value', function () {
@@ -57,6 +112,60 @@ describe('Unit / validator / PropTypes.any', function () {
       })
 
       itValidatesTheProperty(ctx)
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'baz')
+        })
+
+        itValidatesTheProperty(ctx)
+      })
     })
 
     describe('when initialized with function value', function () {
@@ -65,6 +174,60 @@ describe('Unit / validator / PropTypes.any', function () {
       })
 
       itValidatesTheProperty(ctx)
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'baz')
+        })
+
+        itValidatesTheProperty(ctx)
+      })
     })
 
     describe('when initialized with null value', function () {
@@ -73,6 +236,60 @@ describe('Unit / validator / PropTypes.any', function () {
       })
 
       itValidatesTheProperty(ctx)
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'baz')
+        })
+
+        itValidatesTheProperty(ctx)
+      })
     })
 
     describe('when initialized with number value', function () {
@@ -81,6 +298,60 @@ describe('Unit / validator / PropTypes.any', function () {
       })
 
       itValidatesTheProperty(ctx)
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'baz')
+        })
+
+        itValidatesTheProperty(ctx)
+      })
     })
 
     describe('when initialized with object value', function () {
@@ -89,6 +360,60 @@ describe('Unit / validator / PropTypes.any', function () {
       })
 
       itValidatesTheProperty(ctx)
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'baz')
+        })
+
+        itValidatesTheProperty(ctx)
+      })
     })
 
     describe('when initialized with string value', function () {
@@ -97,6 +422,60 @@ describe('Unit / validator / PropTypes.any', function () {
       })
 
       itValidatesTheProperty(ctx)
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'baz')
+        })
+
+        itValidatesTheProperty(ctx)
+      })
     })
 
     describe('when initialized without value', function () {
@@ -105,6 +484,60 @@ describe('Unit / validator / PropTypes.any', function () {
       })
 
       itValidatesTheProperty(ctx, 'Missing required property bar')
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'baz')
+        })
+
+        itValidatesTheProperty(ctx)
+      })
     })
   })
 
@@ -124,6 +557,60 @@ describe('Unit / validator / PropTypes.any', function () {
       })
 
       itValidatesTheProperty(ctx)
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'baz')
+        })
+
+        itValidatesTheProperty(ctx)
+      })
     })
 
     describe('when initialized with boolean value', function () {
@@ -132,6 +619,60 @@ describe('Unit / validator / PropTypes.any', function () {
       })
 
       itValidatesTheProperty(ctx)
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'baz')
+        })
+
+        itValidatesTheProperty(ctx)
+      })
     })
 
     describe('when initialized with function value', function () {
@@ -140,6 +681,60 @@ describe('Unit / validator / PropTypes.any', function () {
       })
 
       itValidatesTheProperty(ctx)
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'baz')
+        })
+
+        itValidatesTheProperty(ctx)
+      })
     })
 
     describe('when initialized with null value', function () {
@@ -148,6 +743,60 @@ describe('Unit / validator / PropTypes.any', function () {
       })
 
       itValidatesTheProperty(ctx)
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'baz')
+        })
+
+        itValidatesTheProperty(ctx)
+      })
     })
 
     describe('when initialized with number value', function () {
@@ -156,6 +805,60 @@ describe('Unit / validator / PropTypes.any', function () {
       })
 
       itValidatesTheProperty(ctx)
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'baz')
+        })
+
+        itValidatesTheProperty(ctx)
+      })
     })
 
     describe('when initialized with object value', function () {
@@ -164,6 +867,60 @@ describe('Unit / validator / PropTypes.any', function () {
       })
 
       itValidatesTheProperty(ctx)
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'baz')
+        })
+
+        itValidatesTheProperty(ctx)
+      })
     })
 
     describe('when initialized with string value', function () {
@@ -172,6 +929,60 @@ describe('Unit / validator / PropTypes.any', function () {
       })
 
       itValidatesTheProperty(ctx)
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'baz')
+        })
+
+        itValidatesTheProperty(ctx)
+      })
     })
 
     describe('when initialized without value', function () {
@@ -180,6 +991,60 @@ describe('Unit / validator / PropTypes.any', function () {
       })
 
       itValidatesTheProperty(ctx)
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'baz')
+        })
+
+        itValidatesTheProperty(ctx)
+      })
     })
   })
 })

--- a/tests/unit/prop-types/array-of-test.js
+++ b/tests/unit/prop-types/array-of-test.js
@@ -32,12 +32,12 @@ const notRequiredDef = {
 
 const shapeTypeDefs = {
   fizz: {
-    isRequired: { required: true, type: 'string' },
+    isRequired: {required: true, type: 'string'},
     required: false,
     type: 'string'
   },
   bang: {
-    isRequired: { required: true, type: 'number' },
+    isRequired: {required: true, type: 'number'},
     required: false,
     type: 'number'
   }

--- a/tests/unit/prop-types/array-test.js
+++ b/tests/unit/prop-types/array-test.js
@@ -2,6 +2,7 @@
  * Unit test for the PropTypes.array validator
  */
 import Ember from 'ember'
+const {Logger} = Ember
 import {afterEach, beforeEach, describe} from 'mocha'
 import sinon from 'sinon'
 
@@ -48,6 +49,60 @@ describe('Unit / validator / PropTypes.array', function () {
       })
 
       itValidatesTheProperty(ctx)
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'spam')
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
+      })
     })
 
     describe('when initialized with number value', function () {
@@ -56,6 +111,60 @@ describe('Unit / validator / PropTypes.array', function () {
       })
 
       itValidatesTheProperty(ctx, 'Expected property bar to be an array')
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'spam')
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
+      })
     })
 
     describe('when initialized without value', function () {
@@ -64,6 +173,60 @@ describe('Unit / validator / PropTypes.array', function () {
       })
 
       itValidatesTheProperty(ctx, 'Missing required property bar')
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'spam')
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
+      })
     })
   })
 
@@ -83,6 +246,60 @@ describe('Unit / validator / PropTypes.array', function () {
       })
 
       itValidatesTheProperty(ctx)
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'spam')
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
+      })
     })
 
     describe('when initialized with number value', function () {
@@ -91,6 +308,60 @@ describe('Unit / validator / PropTypes.array', function () {
       })
 
       itValidatesTheProperty(ctx, 'Expected property bar to be an array')
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'spam')
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
+      })
     })
 
     describe('when initialized without value', function () {
@@ -99,6 +370,60 @@ describe('Unit / validator / PropTypes.array', function () {
       })
 
       itValidatesTheProperty(ctx)
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'spam')
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
+      })
     })
   })
 })

--- a/tests/unit/prop-types/bool-test.js
+++ b/tests/unit/prop-types/bool-test.js
@@ -2,6 +2,7 @@
  * Unit test for the PropTypes.bool validator
  */
 import Ember from 'ember'
+const {Logger} = Ember
 import {afterEach, beforeEach, describe} from 'mocha'
 import sinon from 'sinon'
 
@@ -48,6 +49,60 @@ describe('Unit / validator / PropTypes.bool', function () {
       })
 
       itValidatesTheProperty(ctx)
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'baz')
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
+      })
     })
 
     describe('when initialized with number value', function () {
@@ -56,6 +111,60 @@ describe('Unit / validator / PropTypes.bool', function () {
       })
 
       itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'baz')
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
+      })
     })
 
     describe('when initialized without value', function () {
@@ -64,6 +173,60 @@ describe('Unit / validator / PropTypes.bool', function () {
       })
 
       itValidatesTheProperty(ctx, 'Missing required property bar')
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'baz')
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
+      })
     })
   })
 
@@ -83,6 +246,60 @@ describe('Unit / validator / PropTypes.bool', function () {
       })
 
       itValidatesTheProperty(ctx)
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'baz')
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
+      })
     })
 
     describe('when initialized with number value', function () {
@@ -91,6 +308,60 @@ describe('Unit / validator / PropTypes.bool', function () {
       })
 
       itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'baz')
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
+      })
     })
 
     describe('when initialized without value', function () {
@@ -99,6 +370,60 @@ describe('Unit / validator / PropTypes.bool', function () {
       })
 
       itValidatesTheProperty(ctx)
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'baz')
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
+      })
     })
   })
 })

--- a/tests/unit/prop-types/element-test.js
+++ b/tests/unit/prop-types/element-test.js
@@ -2,6 +2,7 @@
  * Unit test for the PropTypes.element validator
  */
 import Ember from 'ember'
+const {Logger} = Ember
 import {afterEach, beforeEach, describe} from 'mocha'
 import sinon from 'sinon'
 
@@ -48,6 +49,78 @@ describe('Unit / validator / PropTypes.element', function () {
       })
 
       itValidatesTheProperty(ctx)
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
+      })
+
+      describe('when updated with element value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', document.createElement('span'))
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'spam')
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
+      })
+
+      describe('when updated with symbol value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', Symbol())
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
+      })
     })
 
     describe('when initialized with string value', function () {
@@ -56,6 +129,78 @@ describe('Unit / validator / PropTypes.element', function () {
       })
 
       itValidatesTheProperty(ctx, 'Expected property bar to be an element')
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
+      })
+
+      describe('when updated with element value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', document.createElement('span'))
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'spam')
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
+      })
+
+      describe('when updated with symbol value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', Symbol())
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
+      })
     })
 
     describe('when initialized without value', function () {
@@ -64,6 +209,78 @@ describe('Unit / validator / PropTypes.element', function () {
       })
 
       itValidatesTheProperty(ctx, 'Missing required property bar')
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
+      })
+
+      describe('when updated with element value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', document.createElement('span'))
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'spam')
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
+      })
+
+      describe('when updated with symbol value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', Symbol())
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
+      })
     })
   })
 
@@ -83,6 +300,78 @@ describe('Unit / validator / PropTypes.element', function () {
       })
 
       itValidatesTheProperty(ctx)
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
+      })
+
+      describe('when updated with element value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', document.createElement('span'))
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'spam')
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
+      })
+
+      describe('when updated with symbol value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', Symbol())
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
+      })
     })
 
     describe('when initialized with string value', function () {
@@ -91,6 +380,78 @@ describe('Unit / validator / PropTypes.element', function () {
       })
 
       itValidatesTheProperty(ctx, 'Expected property bar to be an element')
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
+      })
+
+      describe('when updated with element value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', document.createElement('span'))
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'spam')
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
+      })
+
+      describe('when updated with symbol value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', Symbol())
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
+      })
     })
 
     describe('when initialized without value', function () {
@@ -99,6 +460,78 @@ describe('Unit / validator / PropTypes.element', function () {
       })
 
       itValidatesTheProperty(ctx)
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
+      })
+
+      describe('when updated with element value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', document.createElement('span'))
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'spam')
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
+      })
+
+      describe('when updated with symbol value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', Symbol())
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
+      })
     })
   })
 })

--- a/tests/unit/prop-types/null-test.js
+++ b/tests/unit/prop-types/null-test.js
@@ -2,6 +2,7 @@
  * Unit test for the PropTypes.null validator
  */
 import Ember from 'ember'
+const {Logger} = Ember
 import {afterEach, beforeEach, describe} from 'mocha'
 import sinon from 'sinon'
 
@@ -48,6 +49,60 @@ describe('Unit / validator / PropTypes.null', function () {
       })
 
       itValidatesTheProperty(ctx)
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be null')
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be null')
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be null')
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be null')
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'spam')
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be null')
+      })
     })
 
     describe('when initialized with number value', function () {
@@ -56,6 +111,60 @@ describe('Unit / validator / PropTypes.null', function () {
       })
 
       itValidatesTheProperty(ctx, 'Expected property bar to be null')
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be null')
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be null')
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be null')
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be null')
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'spam')
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be null')
+      })
     })
 
     describe('when initialized without value', function () {
@@ -64,6 +173,60 @@ describe('Unit / validator / PropTypes.null', function () {
       })
 
       itValidatesTheProperty(ctx, 'Missing required property bar')
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be null')
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be null')
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be null')
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be null')
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'spam')
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be null')
+      })
     })
   })
 
@@ -83,6 +246,60 @@ describe('Unit / validator / PropTypes.null', function () {
       })
 
       itValidatesTheProperty(ctx)
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be null')
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be null')
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be null')
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be null')
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'spam')
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be null')
+      })
     })
 
     describe('when initialized with number value', function () {
@@ -91,6 +308,60 @@ describe('Unit / validator / PropTypes.null', function () {
       })
 
       itValidatesTheProperty(ctx, 'Expected property bar to be null')
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be null')
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be null')
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be null')
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be null')
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'spam')
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be null')
+      })
     })
 
     describe('when initialized without value', function () {
@@ -99,6 +370,60 @@ describe('Unit / validator / PropTypes.null', function () {
       })
 
       itValidatesTheProperty(ctx)
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be null')
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be null')
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be null')
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be null')
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'spam')
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be null')
+      })
     })
   })
 })

--- a/tests/unit/prop-types/number-test.js
+++ b/tests/unit/prop-types/number-test.js
@@ -2,6 +2,7 @@
  * Unit test for the PropTypes.number validator
  */
 import Ember from 'ember'
+const {Logger} = Ember
 import {afterEach, beforeEach, describe} from 'mocha'
 import sinon from 'sinon'
 
@@ -48,6 +49,60 @@ describe('Unit / validator / PropTypes.number', function () {
       })
 
       itValidatesTheProperty(ctx)
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'spam')
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
+      })
     })
 
     describe('when initialized with string value', function () {
@@ -56,6 +111,60 @@ describe('Unit / validator / PropTypes.number', function () {
       })
 
       itValidatesTheProperty(ctx, 'Expected property bar to be a number')
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'spam')
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
+      })
     })
 
     describe('when initialized without value', function () {
@@ -64,6 +173,60 @@ describe('Unit / validator / PropTypes.number', function () {
       })
 
       itValidatesTheProperty(ctx, 'Missing required property bar')
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'spam')
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
+      })
     })
   })
 
@@ -83,6 +246,60 @@ describe('Unit / validator / PropTypes.number', function () {
       })
 
       itValidatesTheProperty(ctx)
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'spam')
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
+      })
     })
 
     describe('when initialized with string value', function () {
@@ -91,6 +308,60 @@ describe('Unit / validator / PropTypes.number', function () {
       })
 
       itValidatesTheProperty(ctx, 'Expected property bar to be a number')
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'spam')
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
+      })
     })
 
     describe('when initialized without value', function () {
@@ -99,6 +370,60 @@ describe('Unit / validator / PropTypes.number', function () {
       })
 
       itValidatesTheProperty(ctx)
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'spam')
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
+      })
     })
   })
 })

--- a/tests/unit/prop-types/object-test.js
+++ b/tests/unit/prop-types/object-test.js
@@ -2,6 +2,7 @@
  * Unit test for the PropTypes.object validator
  */
 import Ember from 'ember'
+const {Logger} = Ember
 import {afterEach, beforeEach, describe} from 'mocha'
 import sinon from 'sinon'
 
@@ -48,6 +49,60 @@ describe('Unit / validator / PropTypes.object', function () {
       })
 
       itValidatesTheProperty(ctx)
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'baz')
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
+      })
     })
 
     describe('when initialized with number value', function () {
@@ -56,6 +111,60 @@ describe('Unit / validator / PropTypes.object', function () {
       })
 
       itValidatesTheProperty(ctx, 'Expected property bar to be an object')
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'baz')
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
+      })
     })
 
     describe('when initialized without value', function () {
@@ -64,6 +173,60 @@ describe('Unit / validator / PropTypes.object', function () {
       })
 
       itValidatesTheProperty(ctx, 'Missing required property bar')
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'baz')
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
+      })
     })
   })
 
@@ -83,6 +246,60 @@ describe('Unit / validator / PropTypes.object', function () {
       })
 
       itValidatesTheProperty(ctx)
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'baz')
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
+      })
     })
 
     describe('when initialized with number value', function () {
@@ -91,6 +308,60 @@ describe('Unit / validator / PropTypes.object', function () {
       })
 
       itValidatesTheProperty(ctx, 'Expected property bar to be an object')
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'baz')
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
+      })
     })
 
     describe('when initialized without value', function () {
@@ -99,6 +370,60 @@ describe('Unit / validator / PropTypes.object', function () {
       })
 
       itValidatesTheProperty(ctx)
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx)
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'baz')
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
+      })
     })
   })
 })

--- a/tests/unit/prop-types/string-test.js
+++ b/tests/unit/prop-types/string-test.js
@@ -2,6 +2,7 @@
  * Unit test for the PropTypes.string validator
  */
 import Ember from 'ember'
+const {Logger} = Ember
 import {afterEach, beforeEach, describe} from 'mocha'
 import sinon from 'sinon'
 
@@ -48,6 +49,60 @@ describe('Unit / validator / PropTypes.string', function () {
       })
 
       itValidatesTheProperty(ctx)
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'baz')
+        })
+
+        itValidatesTheProperty(ctx)
+      })
     })
 
     describe('when initialized with number value', function () {
@@ -56,6 +111,60 @@ describe('Unit / validator / PropTypes.string', function () {
       })
 
       itValidatesTheProperty(ctx, 'Expected property bar to be a string')
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'baz')
+        })
+
+        itValidatesTheProperty(ctx)
+      })
     })
 
     describe('when initialized without value', function () {
@@ -64,6 +173,60 @@ describe('Unit / validator / PropTypes.string', function () {
       })
 
       itValidatesTheProperty(ctx, 'Missing required property bar')
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'baz')
+        })
+
+        itValidatesTheProperty(ctx)
+      })
     })
   })
 
@@ -83,6 +246,60 @@ describe('Unit / validator / PropTypes.string', function () {
       })
 
       itValidatesTheProperty(ctx)
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'baz')
+        })
+
+        itValidatesTheProperty(ctx)
+      })
     })
 
     describe('when initialized with number value', function () {
@@ -91,6 +308,60 @@ describe('Unit / validator / PropTypes.string', function () {
       })
 
       itValidatesTheProperty(ctx, 'Expected property bar to be a string')
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'baz')
+        })
+
+        itValidatesTheProperty(ctx)
+      })
     })
 
     describe('when initialized without value', function () {
@@ -99,6 +370,60 @@ describe('Unit / validator / PropTypes.string', function () {
       })
 
       itValidatesTheProperty(ctx)
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'baz')
+        })
+
+        itValidatesTheProperty(ctx)
+      })
     })
   })
 })

--- a/tests/unit/prop-types/symbol-test.js
+++ b/tests/unit/prop-types/symbol-test.js
@@ -2,6 +2,7 @@
  * Unit test for the PropTypes.symbol validator
  */
 import Ember from 'ember'
+const {Logger} = Ember
 import {afterEach, beforeEach, describe} from 'mocha'
 import sinon from 'sinon'
 
@@ -48,6 +49,69 @@ describe('Unit / validator / PropTypes.symbol', function () {
       })
 
       itValidatesTheProperty(ctx)
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'spam')
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
+      })
+
+      describe('when updated with symbol value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', Symbol())
+        })
+
+        itValidatesTheProperty(ctx)
+      })
     })
 
     describe('when initialized with string value', function () {
@@ -56,6 +120,69 @@ describe('Unit / validator / PropTypes.symbol', function () {
       })
 
       itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'spam')
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
+      })
+
+      describe('when updated with symbol value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', Symbol())
+        })
+
+        itValidatesTheProperty(ctx)
+      })
     })
 
     describe('when initialized without value', function () {
@@ -64,6 +191,69 @@ describe('Unit / validator / PropTypes.symbol', function () {
       })
 
       itValidatesTheProperty(ctx, 'Missing required property bar')
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'spam')
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
+      })
+
+      describe('when updated with symbol value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', Symbol())
+        })
+
+        itValidatesTheProperty(ctx)
+      })
     })
   })
 
@@ -83,6 +273,69 @@ describe('Unit / validator / PropTypes.symbol', function () {
       })
 
       itValidatesTheProperty(ctx)
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'spam')
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
+      })
+
+      describe('when updated with symbol value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', Symbol())
+        })
+
+        itValidatesTheProperty(ctx)
+      })
     })
 
     describe('when initialized with string value', function () {
@@ -91,6 +344,69 @@ describe('Unit / validator / PropTypes.symbol', function () {
       })
 
       itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'spam')
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
+      })
+
+      describe('when updated with symbol value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', Symbol())
+        })
+
+        itValidatesTheProperty(ctx)
+      })
     })
 
     describe('when initialized without value', function () {
@@ -99,6 +415,69 @@ describe('Unit / validator / PropTypes.symbol', function () {
       })
 
       itValidatesTheProperty(ctx)
+
+      describe('when updated with array value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', [])
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
+      })
+
+      describe('when updated with boolean value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', false)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
+      })
+
+      describe('when updated with null value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', null)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
+      })
+
+      describe('when updated with number value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 2)
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
+      })
+
+      describe('when updated with object value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', {})
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
+      })
+
+      describe('when updated with string value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', 'spam')
+        })
+
+        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
+      })
+
+      describe('when updated with symbol value', function () {
+        beforeEach(function () {
+          Logger.warn.reset()
+          ctx.instance.set('bar', Symbol())
+        })
+
+        itValidatesTheProperty(ctx)
+      })
     })
   })
 })


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Added** opt-in validation checks when properties that are spec'd in `propTypes` are updated. To enable this feature simply add the following to `config/environment.js`:

  ```js
  'ember-prop-types': {
    validateOnUpdate: true
  }
  ```
