### PR TITLE
Add ability to throw errors for validation errors

### DIFF
--- a/addon/mixins/prop-types.js
+++ b/addon/mixins/prop-types.js
@@ -8,6 +8,20 @@ import config from 'ember-get-config'
 import PropTypes, {logger, validators} from '../utils/prop-types'
 
 const helpers = {
+  handleError (ctx, message) {
+    const shouldThrow = getWithDefault(config, 'ember-prop-types.throwErrors', false)
+
+    if (shouldThrow) {
+      helpers.throwError(message)
+    } else {
+      logger.warn(ctx, message)
+    }
+  },
+
+  throwError (message) {
+    throw new Error(message)
+  },
+
   /* eslint-disable complexity */
   validateProperty (ctx, name, def) {
     const value = ctx.get(name)
@@ -17,7 +31,7 @@ const helpers = {
         return
       }
 
-      logger.warn(ctx, `Missing required property ${name}`)
+      helpers.handleError(ctx, `Missing required property ${name}`)
 
       return
     }
@@ -25,7 +39,7 @@ const helpers = {
     if (def.type in validators) {
       validators[def.type](ctx, name, value, def, true)
     } else {
-      logger.warn(ctx, `Unknown propType ${def.type}`)
+      helpers.handleError(ctx, `Unknown propType ${def.type}`)
     }
   },
   /* eslint-enable complexity */
@@ -45,7 +59,7 @@ const helpers = {
         const def = propType[name]
 
         if (def === undefined) {
-          logger.warn(ctx, `propType for ${name} is unknown`)
+          helpers.handleError(ctx, `propType for ${name} is unknown`)
           return
         }
 

--- a/addon/mixins/prop-types.js
+++ b/addon/mixins/prop-types.js
@@ -7,19 +7,16 @@ import config from 'ember-get-config'
 
 import PropTypes, {logger, validators} from '../utils/prop-types'
 
-const helpers = {
-  handleError (ctx, message) {
-    const shouldThrow = getWithDefault(config, 'ember-prop-types.throwErrors', false)
-
-    if (shouldThrow) {
-      helpers.throwError(message)
-    } else {
-      logger.warn(ctx, message)
+export const helpers = {
+  getSettings () {
+    return {
+      throwErrors: getWithDefault(config, 'ember-prop-types.throwErrors', false),
+      validateOnUpdate: getWithDefault(config, 'ember-prop-types.validateOnUpdate', false)
     }
   },
 
-  throwError (message) {
-    throw new Error(message)
+  handleError (ctx, message) {
+    logger.warn(ctx, message, helpers.getSettings().throwErrors)
   },
 
   /* eslint-disable complexity */
@@ -37,7 +34,7 @@ const helpers = {
     }
 
     if (def.type in validators) {
-      validators[def.type](ctx, name, value, def, true)
+      validators[def.type](ctx, name, value, def, true, helpers.getSettings().throwErrors)
     } else {
       helpers.handleError(ctx, `Unknown propType ${def.type}`)
     }
@@ -63,7 +60,7 @@ const helpers = {
           return
         }
 
-        if (getWithDefault(config, 'ember-prop-types.validateOnUpdate', false)) {
+        if (helpers.getSettings().validateOnUpdate) {
           ctx.addObserver(name, ctx, function () {
             helpers.validateProperty(this, name, def)
           })
@@ -106,4 +103,4 @@ export default Mixin.create({
   }
 })
 
-export {helpers, PropTypes}
+export {PropTypes}

--- a/addon/mixins/prop-types.js
+++ b/addon/mixins/prop-types.js
@@ -7,16 +7,14 @@ import config from 'ember-get-config'
 
 import PropTypes, {logger, validators} from '../utils/prop-types'
 
-export const helpers = {
-  getSettings () {
-    return {
-      throwErrors: getWithDefault(config, 'ember-prop-types.throwErrors', false),
-      validateOnUpdate: getWithDefault(config, 'ember-prop-types.validateOnUpdate', false)
-    }
-  },
+export const settings = {
+  throwErrors: getWithDefault(config, 'ember-prop-types.throwErrors', false),
+  validateOnUpdate: getWithDefault(config, 'ember-prop-types.validateOnUpdate', false)
+}
 
+export const helpers = {
   handleError (ctx, message) {
-    logger.warn(ctx, message, helpers.getSettings().throwErrors)
+    logger.warn(ctx, message, settings.throwErrors)
   },
 
   /* eslint-disable complexity */
@@ -34,7 +32,7 @@ export const helpers = {
     }
 
     if (def.type in validators) {
-      validators[def.type](ctx, name, value, def, true, helpers.getSettings().throwErrors)
+      validators[def.type](ctx, name, value, def, true, settings.throwErrors)
     } else {
       helpers.handleError(ctx, `Unknown propType ${def.type}`)
     }
@@ -60,7 +58,7 @@ export const helpers = {
           return
         }
 
-        if (helpers.getSettings().validateOnUpdate) {
+        if (settings.validateOnUpdate) {
           ctx.addObserver(name, ctx, function () {
             helpers.validateProperty(this, name, def)
           })

--- a/addon/utils/logger.js
+++ b/addon/utils/logger.js
@@ -4,12 +4,23 @@
 import Ember from 'ember'
 const {Logger} = Ember
 
-/**
- * Log a warning message
- * @param {*} obj - the object doing the warning
- * @param {String} message - the warning message
- */
-export function warn (obj, message) {
-  const id = obj.toString()
-  Logger.warn(`[${id}]: ${message}`)
+export default {
+  throwError (message) {
+    throw new Error(message)
+  },
+
+  /**
+   * Log a warning message
+   * @param {*} obj - the object doing the warning
+   * @param {String} message - the warning
+   * @param {Boolean} throwError - whether or not to throw error
+   */
+  warn (obj, message, throwError) {
+    if (throwError) {
+      this.throwError(message)
+    } else {
+      const id = obj.toString()
+      Logger.warn(`[${id}]: ${message}`)
+    }
+  }
 }

--- a/addon/utils/prop-types.js
+++ b/addon/utils/prop-types.js
@@ -1,4 +1,4 @@
-import * as logger from './logger'
+import logger from './logger'
 import validators from './validators'
 
 const PropTypes = {}

--- a/addon/utils/validators/array-of.js
+++ b/addon/utils/validators/array-of.js
@@ -1,18 +1,18 @@
 /**
  * The PropTypes.arrayOf validator
  */
-import * as logger from '../logger'
+import logger from '../logger'
 const {isArray} = Array
 
-export default function (validators, ctx, name, value, def, logErrors) {
+export default function (validators, ctx, name, value, def, logErrors, throwErrors) {
   const typeDef = def.typeDef
 
   const valid = isArray(value) && value.every((item, index) => {
-    return validators[typeDef.type](ctx, `${name}[${index}]`, item, typeDef, logErrors)
+    return validators[typeDef.type](ctx, `${name}[${index}]`, item, typeDef, logErrors, throwErrors)
   })
 
   if (!valid && logErrors) {
-    logger.warn(ctx, `Expected property ${name} to be an array of type ${typeDef.type}`)
+    logger.warn(ctx, `Expected property ${name} to be an array of type ${typeDef.type}`, throwErrors)
   }
 
   return valid

--- a/addon/utils/validators/array.js
+++ b/addon/utils/validators/array.js
@@ -4,13 +4,13 @@
 import Ember from 'ember'
 const {typeOf} = Ember
 
-import * as logger from '../logger'
+import logger from '../logger'
 
-export default function (ctx, name, value, def, logErrors) {
+export default function (ctx, name, value, def, logErrors, throwErrors) {
   const valid = typeOf(value) === 'array'
 
   if (!valid && logErrors) {
-    logger.warn(ctx, `Expected property ${name} to be an array`)
+    logger.warn(ctx, `Expected property ${name} to be an array`, throwErrors)
   }
 
   return valid

--- a/addon/utils/validators/bool.js
+++ b/addon/utils/validators/bool.js
@@ -4,13 +4,13 @@
 import Ember from 'ember'
 const {typeOf} = Ember
 
-import * as logger from '../logger'
+import logger from '../logger'
 
-export default function (ctx, name, value, def, logErrors) {
+export default function (ctx, name, value, def, logErrors, throwErrors) {
   const valid = typeOf(value) === 'boolean'
 
   if (!valid && logErrors) {
-    logger.warn(ctx, `Expected property ${name} to be a boolean`)
+    logger.warn(ctx, `Expected property ${name} to be a boolean`, throwErrors)
   }
 
   return valid

--- a/addon/utils/validators/element.js
+++ b/addon/utils/validators/element.js
@@ -4,13 +4,13 @@
 
 /* global Element */
 
-import * as logger from '../logger'
+import logger from '../logger'
 
-export default function (ctx, name, value, def, logErrors) {
+export default function (ctx, name, value, def, logErrors, throwErrors) {
   const valid = value instanceof Element
 
   if (!valid && logErrors) {
-    logger.warn(ctx, `Expected property ${name} to be an element`)
+    logger.warn(ctx, `Expected property ${name} to be an element`, throwErrors)
   }
 
   return valid

--- a/addon/utils/validators/ember-object.js
+++ b/addon/utils/validators/ember-object.js
@@ -5,13 +5,13 @@
 import Ember from 'ember'
 const {typeOf} = Ember
 
-import * as logger from '../logger'
+import logger from '../logger'
 
-export default function (ctx, name, value, def, logErrors) {
+export default function (ctx, name, value, def, logErrors, throwErrors) {
   const valid = typeOf(value) === ('instance' || 'class')
 
   if (!valid && logErrors) {
-    logger.warn(ctx, `Expected property ${name} to be an Ember.Object`)
+    logger.warn(ctx, `Expected property ${name} to be an Ember.Object`, throwErrors)
   }
 
   return valid

--- a/addon/utils/validators/func.js
+++ b/addon/utils/validators/func.js
@@ -5,13 +5,13 @@
 import Ember from 'ember'
 const {typeOf} = Ember
 
-import * as logger from '../logger'
+import logger from '../logger'
 
-export default function (ctx, name, value, def, logErrors) {
+export default function (ctx, name, value, def, logErrors, throwErrors) {
   const valid = typeOf(value) === 'function'
 
   if (!valid && logErrors) {
-    logger.warn(ctx, `Expected property ${name} to be a function`)
+    logger.warn(ctx, `Expected property ${name} to be a function`, throwErrors)
   }
 
   return valid

--- a/addon/utils/validators/instance-of.js
+++ b/addon/utils/validators/instance-of.js
@@ -2,15 +2,15 @@
  * The PropTypes.instanceOf validator
  */
 
-import * as logger from '../logger'
+import logger from '../logger'
 
-export default function (ctx, name, value, def, logErrors) {
+export default function (ctx, name, value, def, logErrors, throwErrors) {
   const type = def.typeDef
   const valid = value instanceof type
 
   if (!valid && logErrors) {
     const nameOfType = type.toString().match(/function (\w*)/)[1]
-    logger.warn(ctx, `Expected property ${name} to be an instance of ${nameOfType}`)
+    logger.warn(ctx, `Expected property ${name} to be an instance of ${nameOfType}`, throwErrors)
   }
 
   return valid

--- a/addon/utils/validators/null.js
+++ b/addon/utils/validators/null.js
@@ -2,13 +2,13 @@
  * The PropTypes.null validator
  */
 
-import * as logger from '../logger'
+import logger from '../logger'
 
-export default function (ctx, name, value, def, logErrors) {
+export default function (ctx, name, value, def, logErrors, throwErrors) {
   const valid = value === null
 
   if (!valid && logErrors) {
-    logger.warn(ctx, `Expected property ${name} to be null`)
+    logger.warn(ctx, `Expected property ${name} to be null`, throwErrors)
   }
 
   return valid

--- a/addon/utils/validators/number.js
+++ b/addon/utils/validators/number.js
@@ -5,13 +5,13 @@
 import Ember from 'ember'
 const {typeOf} = Ember
 
-import * as logger from '../logger'
+import logger from '../logger'
 
-export default function (ctx, name, value, def, logErrors) {
+export default function (ctx, name, value, def, logErrors, throwErrors) {
   const valid = typeOf(value) === 'number'
 
   if (!valid && logErrors) {
-    logger.warn(ctx, `Expected property ${name} to be a number`)
+    logger.warn(ctx, `Expected property ${name} to be a number`, throwErrors)
   }
 
   return valid

--- a/addon/utils/validators/object.js
+++ b/addon/utils/validators/object.js
@@ -5,13 +5,13 @@
 import Ember from 'ember'
 const {typeOf} = Ember
 
-import * as logger from '../logger'
+import logger from '../logger'
 
-export default function (ctx, name, value, def, logErrors) {
+export default function (ctx, name, value, def, logErrors, throwErrors) {
   const valid = typeOf(value) === 'object'
 
   if (!valid && logErrors) {
-    logger.warn(ctx, `Expected property ${name} to be an object`)
+    logger.warn(ctx, `Expected property ${name} to be an object`, throwErrors)
   }
 
   return valid

--- a/addon/utils/validators/one-of-type.js
+++ b/addon/utils/validators/one-of-type.js
@@ -5,13 +5,13 @@
 import Ember from 'ember'
 const {typeOf} = Ember
 
-import * as logger from '../logger'
+import logger from '../logger'
 
-export default function (validators, ctx, name, value, def) {
+export default function (validators, ctx, name, value, def, logErrors, throwErrors) {
   let valid = false
 
   if (typeOf(def.typeDefs) !== 'array') {
-    logger.warn(ctx, 'PropTypes.oneOfType() requires an array of types to be passed in as an argument')
+    logger.warn(ctx, 'PropTypes.oneOfType() requires an array of types to be passed in as an argument', throwErrors)
 
     return valid
   }
@@ -27,7 +27,7 @@ export default function (validators, ctx, name, value, def) {
 
   if (!valid) {
     const types = def.typeDefs.map((typeDef) => typeDef.type)
-    logger.warn(ctx, `Property ${name} does not match expected types: ${types.join(', ')}`)
+    logger.warn(ctx, `Property ${name} does not match expected types: ${types.join(', ')}`, throwErrors)
   }
 
   return valid

--- a/addon/utils/validators/one-of.js
+++ b/addon/utils/validators/one-of.js
@@ -5,20 +5,20 @@
 import Ember from 'ember'
 const {typeOf} = Ember
 
-import * as logger from '../logger'
+import logger from '../logger'
 
-export default function (ctx, name, value, def, logErrors) {
+export default function (ctx, name, value, def, logErrors, throwErrors) {
   const valueOptions = def.valueOptions
 
   if (typeOf(valueOptions) !== 'array') {
-    logger.warn(ctx, 'PropTypes.oneOf() requires an array of values to be passed in as an argument')
+    logger.warn(ctx, 'PropTypes.oneOf() requires an array of values to be passed in as an argument', throwErrors)
     return false
   }
 
   const valid = valueOptions.some((option) => option === value)
 
   if (!valid && logErrors) {
-    logger.warn(ctx, `Property ${name} is not one of: ${valueOptions.join(', ')}`)
+    logger.warn(ctx, `Property ${name} is not one of: ${valueOptions.join(', ')}`, throwErrors)
   }
 
   return valid

--- a/addon/utils/validators/shape.js
+++ b/addon/utils/validators/shape.js
@@ -5,17 +5,17 @@
 import Ember from 'ember'
 const {get, typeOf} = Ember
 
-import * as logger from '../logger'
+import logger from '../logger'
 
-export default function (validators, ctx, name, value, def, logErrors) {
+export default function (validators, ctx, name, value, def, logErrors, throwErrors) {
   const typeDefs = def.typeDefs
   if (typeOf(typeDefs) !== 'object') {
-    logger.warn(ctx, 'PropTypes.shape() requires a plain object to be be passed in as an argument')
+    logger.warn(ctx, 'PropTypes.shape() requires a plain object to be be passed in as an argument', throwErrors)
     return false
   }
 
   if (typeOf(value) !== 'object') {
-    logger.warn(ctx, `Property ${name} does not match the given shape`)
+    logger.warn(ctx, `Property ${name} does not match the given shape`, throwErrors)
     return false
   }
 
@@ -28,25 +28,25 @@ export default function (validators, ctx, name, value, def, logErrors) {
         return true
       } else {
         if (logErrors) {
-          logger.warn(ctx, `Property ${name} is missing required property ${key}`)
+          logger.warn(ctx, `Property ${name} is missing required property ${key}`, throwErrors)
         }
         return false
       }
     }
 
-    return validators[typeDef.type](ctx, `${name}.${key}`, objectValue, typeDef, logErrors)
+    return validators[typeDef.type](ctx, `${name}.${key}`, objectValue, typeDef, logErrors, throwErrors)
   })
 
   valid = valid && Object.keys(value).every((key) => {
     const keyIsKnown = (key in typeDefs)
     if (!keyIsKnown && logErrors) {
-      logger.warn(ctx, `Property ${name} has an unknown key: ${key}`)
+      logger.warn(ctx, `Property ${name} has an unknown key: ${key}`, throwErrors)
     }
     return keyIsKnown
   })
 
   if (!valid && logErrors) {
-    logger.warn(ctx, `Property ${name} does not match the given shape`)
+    logger.warn(ctx, `Property ${name} does not match the given shape`, throwErrors)
   }
 
   return valid

--- a/addon/utils/validators/string.js
+++ b/addon/utils/validators/string.js
@@ -5,13 +5,13 @@
 import Ember from 'ember'
 const {typeOf} = Ember
 
-import * as logger from '../logger'
+import logger from '../logger'
 
-export default function (ctx, name, value, def, logErrors) {
+export default function (ctx, name, value, def, logErrors, throwErrors) {
   const valid = typeOf(value) === 'string'
 
   if (!valid && logErrors) {
-    logger.warn(ctx, `Expected property ${name} to be a string`)
+    logger.warn(ctx, `Expected property ${name} to be a string`, throwErrors)
   }
 
   return valid

--- a/addon/utils/validators/symbol.js
+++ b/addon/utils/validators/symbol.js
@@ -2,13 +2,13 @@
  * The PropTypes.symbol validator
  */
 
-import * as logger from '../logger'
+import logger from '../logger'
 
-export default function (ctx, name, value, def, logErrors) {
+export default function (ctx, name, value, def, logErrors, throwErrors) {
   const valid = typeof value === 'symbol'
 
   if (!valid && logErrors) {
-    logger.warn(ctx, `Expected property ${name} to be a symbol`)
+    logger.warn(ctx, `Expected property ${name} to be a symbol`, throwErrors)
   }
 
   return valid

--- a/tests/dummy/app/index.html
+++ b/tests/dummy/app/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>Dummy</title>
+    <title>ember-prop-types</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -25,11 +25,25 @@ export default Component.extend(PropTypeMixin, {
 
 `
 
+const errorConfig = `
+'ember-prop-types': {
+  throwErrors: true
+}
+`
+
+const updateConfig = `
+'ember-prop-types': {
+  validateOnUpdate: true
+}
+`
+
 export default Route.extend({
   model () {
     return {
       contributors,
       defaultsExample,
+      errorConfig,
+      updateConfig,
       validators
     }
   }

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -16,6 +16,20 @@
   all default property values under a single method.
 </p>
 
+<p>
+  Out-of-box <em>ember-prop-types</em> informs users of validation errors by logging warnings to the console.
+  Alternativeley you can configure <em>ember-prop-types</em> to throw errors instead with the following in
+  <em>config/environment.js</em>:
+  {{#code-block language="javascript"}}{{model.errorConfig}}{{/code-block}}
+</p>
+
+<p>
+  Out-of-box <em>ember-prop-types</em> will only run validation checks when objects are intialized, not on property
+  updates. If you'd like to also run validation on property updates you can enable it with the following in
+  <em>config/environment.js</em>:
+  {{#code-block language="javascript"}}{{model.updateConfig}}{{/code-block}}
+</p>
+
 <h2>Validators</h2>
 
 <div class="flex">

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -13,6 +13,7 @@ module.exports = function (environment) {
     modulePrefix: 'dummy',
 
     'ember-prop-types': {
+      throwErrors: false,
       validateOnUpdate: true
     }
   }

--- a/tests/helpers/validator.js
+++ b/tests/helpers/validator.js
@@ -4,9 +4,249 @@
 import {expect} from 'chai'
 import Ember from 'ember'
 const {Logger} = Ember
-import {beforeEach, it} from 'mocha'
+import config from 'ember-get-config'
+import {beforeEach, describe, it} from 'mocha'
 
 import {helpers} from 'ember-prop-types/mixins/prop-types'
+
+export function itValidatesOnUpdate (ctx, type, warningMessage) {
+  describe('when throwErrors not set', function () {
+    beforeEach(function () {
+      config['ember-prop-types'] = {
+        validateOnUpdate: true
+      }
+
+      Logger.warn.reset()
+    })
+
+    describe('with array value', function () {
+      beforeEach(function () {
+        ctx.instance.set('bar', [])
+      })
+
+      if (type === 'array') {
+        itValidatesTheProperty(ctx, false)
+      } else {
+        itValidatesTheProperty(ctx, false, warningMessage)
+      }
+    })
+
+    describe('with boolean value', function () {
+      beforeEach(function () {
+        ctx.instance.set('bar', false)
+      })
+
+      if (type === 'bool') {
+        itValidatesTheProperty(ctx, false)
+      } else {
+        itValidatesTheProperty(ctx, false, warningMessage)
+      }
+    })
+
+    describe('with element value', function () {
+      beforeEach(function () {
+        ctx.instance.set('bar', document.createElement('span'))
+      })
+
+      if (['element', 'object'].indexOf(type) !== -1) {
+        itValidatesTheProperty(ctx, false)
+      } else {
+        itValidatesTheProperty(ctx, false, warningMessage)
+      }
+    })
+
+    describe('with function value', function () {
+      beforeEach(function () {
+        ctx.instance.set('bar', () => {})
+      })
+
+      if (type === 'func') {
+        itValidatesTheProperty(ctx, false)
+      } else {
+        itValidatesTheProperty(ctx, false, warningMessage)
+      }
+    })
+
+    describe('with null value', function () {
+      beforeEach(function () {
+        ctx.instance.set('bar', null)
+      })
+
+      if (type === 'null') {
+        itValidatesTheProperty(ctx, false)
+      } else {
+        itValidatesTheProperty(ctx, false, warningMessage)
+      }
+    })
+
+    describe('with number value', function () {
+      beforeEach(function () {
+        ctx.instance.set('bar', 2)
+      })
+
+      if (type === 'number') {
+        itValidatesTheProperty(ctx, false)
+      } else {
+        itValidatesTheProperty(ctx, false, warningMessage)
+      }
+    })
+
+    describe('with object value', function () {
+      beforeEach(function () {
+        ctx.instance.set('bar', {})
+      })
+
+      if (type === 'object') {
+        itValidatesTheProperty(ctx, false)
+      } else {
+        itValidatesTheProperty(ctx, false, warningMessage)
+      }
+    })
+
+    describe('with string value', function () {
+      beforeEach(function () {
+        ctx.instance.set('bar', 'spam')
+      })
+
+      if (type === 'string') {
+        itValidatesTheProperty(ctx, false)
+      } else {
+        itValidatesTheProperty(ctx, false, warningMessage)
+      }
+    })
+
+    describe('with symbol value', function () {
+      beforeEach(function () {
+        ctx.instance.set('bar', Symbol())
+      })
+
+      if (['object', 'symbol'].indexOf(type) !== -1) {
+        itValidatesTheProperty(ctx, false)
+      } else {
+        itValidatesTheProperty(ctx, false, warningMessage)
+      }
+    })
+  })
+
+  describe('when throwErrors set to false', function () {
+    beforeEach(function () {
+      config['ember-prop-types'] = {
+        throwErrors: false,
+        validateOnUpdate: true
+      }
+
+      Logger.warn.reset()
+    })
+
+    describe('with array value', function () {
+      beforeEach(function () {
+        ctx.instance.set('bar', [])
+      })
+
+      if (type === 'array') {
+        itValidatesTheProperty(ctx, false)
+      } else {
+        itValidatesTheProperty(ctx, false, warningMessage)
+      }
+    })
+
+    describe('with boolean value', function () {
+      beforeEach(function () {
+        ctx.instance.set('bar', false)
+      })
+
+      if (type === 'bool') {
+        itValidatesTheProperty(ctx, false)
+      } else {
+        itValidatesTheProperty(ctx, false, warningMessage)
+      }
+    })
+
+    describe('with element value', function () {
+      beforeEach(function () {
+        ctx.instance.set('bar', document.createElement('span'))
+      })
+
+      if (['element', 'object'].indexOf(type) !== -1) {
+        itValidatesTheProperty(ctx, false)
+      } else {
+        itValidatesTheProperty(ctx, false, warningMessage)
+      }
+    })
+
+    describe('with function value', function () {
+      beforeEach(function () {
+        ctx.instance.set('bar', () => {})
+      })
+
+      if (type === 'func') {
+        itValidatesTheProperty(ctx, false)
+      } else {
+        itValidatesTheProperty(ctx, false, warningMessage)
+      }
+    })
+
+    describe('with null value', function () {
+      beforeEach(function () {
+        ctx.instance.set('bar', null)
+      })
+
+      if (type === 'null') {
+        itValidatesTheProperty(ctx, false)
+      } else {
+        itValidatesTheProperty(ctx, false, warningMessage)
+      }
+    })
+
+    describe('with number value', function () {
+      beforeEach(function () {
+        ctx.instance.set('bar', 2)
+      })
+
+      if (type === 'number') {
+        itValidatesTheProperty(ctx, false)
+      } else {
+        itValidatesTheProperty(ctx, false, warningMessage)
+      }
+    })
+
+    describe('with object value', function () {
+      beforeEach(function () {
+        ctx.instance.set('bar', {})
+      })
+
+      if (type === 'object') {
+        itValidatesTheProperty(ctx, false)
+      } else {
+        itValidatesTheProperty(ctx, false, warningMessage)
+      }
+    })
+
+    describe('with string value', function () {
+      beforeEach(function () {
+        ctx.instance.set('bar', 'spam')
+      })
+
+      if (type === 'string') {
+        itValidatesTheProperty(ctx, false)
+      } else {
+        itValidatesTheProperty(ctx, false, warningMessage)
+      }
+    })
+
+    describe('with symbol value', function () {
+      beforeEach(function () {
+        ctx.instance.set('bar', Symbol())
+      })
+
+      if (['object', 'symbol'].indexOf(type) !== -1) {
+        itValidatesTheProperty(ctx, false)
+      } else {
+        itValidatesTheProperty(ctx, false, warningMessage)
+      }
+    })
+  })
+}
 
 /**
  * Ensure that the proper validation methods are called and that no warning is logged
@@ -18,9 +258,10 @@ import {helpers} from 'ember-prop-types/mixins/prop-types'
  * @param {Object} ctx.def - the propType definition
  * @param {Object} ctx.instance - the object instance that has the mixin
  * @param {String} ctx.propertyName - the object instance that has the mixin
+ * @param {Boolean} throwErrors - whether or not errors should be thrown
  * @param {String[]} [warningMessages] - if present, expect Logger.warn to be called with them, else expect no warnings
  */
-export function itValidatesTheProperty (ctx, ...warningMessages) {
+export function itValidatesTheProperty (ctx, throwErrors, ...warningMessages) {
   let def, instance, propertyName
 
   beforeEach(function () {
@@ -37,17 +278,23 @@ export function itValidatesTheProperty (ctx, ...warningMessages) {
     expect(helpers.validateProperty).to.have.been.calledWith(instance, propertyName, def)
   })
 
-  if (warningMessages.length > 0) {
-    it('should log warning(s)', function () {
-      expect(Logger.warn).to.have.callCount(warningMessages.length)
-      warningMessages.forEach((msg) => {
-        expect(Logger.warn).to.have.been.calledWith(`[${instance.toString()}]: ${msg}`)
-      })
-    })
-  } else {
+  if (throwErrors) {
     it('should not log warning', function () {
       expect(Logger.warn).to.have.callCount(0)
     })
+  } else {
+    if (warningMessages.length > 0) {
+      it('should log warning(s)', function () {
+        expect(Logger.warn).to.have.callCount(warningMessages.length)
+        warningMessages.forEach((msg) => {
+          expect(Logger.warn).to.have.been.calledWith(`[${instance.toString()}]: ${msg}`)
+        })
+      })
+    } else {
+      it('should not log warning', function () {
+        expect(Logger.warn).to.have.callCount(0)
+      })
+    }
   }
 }
 

--- a/tests/helpers/validator.js
+++ b/tests/helpers/validator.js
@@ -4,22 +4,35 @@
 import {expect} from 'chai'
 import Ember from 'ember'
 const {Logger} = Ember
-import config from 'ember-get-config'
-import {beforeEach, describe, it} from 'mocha'
+import {after, before, beforeEach, describe, it} from 'mocha'
+import sinon from 'sinon'
 
 import {helpers} from 'ember-prop-types/mixins/prop-types'
+import logger from 'ember-prop-types/utils/logger'
 
 export function itValidatesOnUpdate (ctx, type, warningMessage) {
-  describe('when throwErrors not set', function () {
-    beforeEach(function () {
-      config['ember-prop-types'] = {
-        validateOnUpdate: true
-      }
+  describe('when throwErrors set to false', function () {
+    let getSettingsStub
 
-      Logger.warn.reset()
+    before(function () {
+      getSettingsStub = sinon.stub(helpers, 'getSettings', () => {
+        return {
+          throwErrors: false,
+          validateOnUpdate: true
+        }
+      })
     })
 
-    describe('with array value', function () {
+    beforeEach(function () {
+      Logger.warn.reset()
+      logger.throwError.reset()
+    })
+
+    after(function () {
+      getSettingsStub.restore()
+    })
+
+    describe('updated with array value', function () {
       beforeEach(function () {
         ctx.instance.set('bar', [])
       })
@@ -31,7 +44,7 @@ export function itValidatesOnUpdate (ctx, type, warningMessage) {
       }
     })
 
-    describe('with boolean value', function () {
+    describe('updated with boolean value', function () {
       beforeEach(function () {
         ctx.instance.set('bar', false)
       })
@@ -43,7 +56,7 @@ export function itValidatesOnUpdate (ctx, type, warningMessage) {
       }
     })
 
-    describe('with element value', function () {
+    describe('updated with element value', function () {
       beforeEach(function () {
         ctx.instance.set('bar', document.createElement('span'))
       })
@@ -55,7 +68,7 @@ export function itValidatesOnUpdate (ctx, type, warningMessage) {
       }
     })
 
-    describe('with function value', function () {
+    describe('updated with function value', function () {
       beforeEach(function () {
         ctx.instance.set('bar', () => {})
       })
@@ -67,7 +80,7 @@ export function itValidatesOnUpdate (ctx, type, warningMessage) {
       }
     })
 
-    describe('with null value', function () {
+    describe('updated with null value', function () {
       beforeEach(function () {
         ctx.instance.set('bar', null)
       })
@@ -79,7 +92,7 @@ export function itValidatesOnUpdate (ctx, type, warningMessage) {
       }
     })
 
-    describe('with number value', function () {
+    describe('updated with number value', function () {
       beforeEach(function () {
         ctx.instance.set('bar', 2)
       })
@@ -91,7 +104,7 @@ export function itValidatesOnUpdate (ctx, type, warningMessage) {
       }
     })
 
-    describe('with object value', function () {
+    describe('updated with object value', function () {
       beforeEach(function () {
         ctx.instance.set('bar', {})
       })
@@ -103,7 +116,7 @@ export function itValidatesOnUpdate (ctx, type, warningMessage) {
       }
     })
 
-    describe('with string value', function () {
+    describe('updated with string value', function () {
       beforeEach(function () {
         ctx.instance.set('bar', 'spam')
       })
@@ -115,7 +128,7 @@ export function itValidatesOnUpdate (ctx, type, warningMessage) {
       }
     })
 
-    describe('with symbol value', function () {
+    describe('updated with symbol value', function () {
       beforeEach(function () {
         ctx.instance.set('bar', Symbol())
       })
@@ -128,121 +141,132 @@ export function itValidatesOnUpdate (ctx, type, warningMessage) {
     })
   })
 
-  describe('when throwErrors set to false', function () {
-    beforeEach(function () {
-      config['ember-prop-types'] = {
-        throwErrors: false,
-        validateOnUpdate: true
-      }
+  describe('when throwErrors set to true', function () {
+    let getSettingsStub
 
-      Logger.warn.reset()
+    before(function () {
+      getSettingsStub = sinon.stub(helpers, 'getSettings', () => {
+        return {
+          throwErrors: true,
+          validateOnUpdate: true
+        }
+      })
     })
 
-    describe('with array value', function () {
+    beforeEach(function () {
+      Logger.warn.reset()
+      logger.throwError.reset()
+    })
+
+    after(function () {
+      getSettingsStub.restore()
+    })
+
+    describe('updated with array value', function () {
       beforeEach(function () {
         ctx.instance.set('bar', [])
       })
 
       if (type === 'array') {
-        itValidatesTheProperty(ctx, false)
+        itValidatesTheProperty(ctx, true)
       } else {
-        itValidatesTheProperty(ctx, false, warningMessage)
+        itValidatesTheProperty(ctx, true, warningMessage)
       }
     })
 
-    describe('with boolean value', function () {
+    describe('updated with boolean value', function () {
       beforeEach(function () {
         ctx.instance.set('bar', false)
       })
 
       if (type === 'bool') {
-        itValidatesTheProperty(ctx, false)
+        itValidatesTheProperty(ctx, true)
       } else {
-        itValidatesTheProperty(ctx, false, warningMessage)
+        itValidatesTheProperty(ctx, true, warningMessage)
       }
     })
 
-    describe('with element value', function () {
+    describe('updated with element value', function () {
       beforeEach(function () {
         ctx.instance.set('bar', document.createElement('span'))
       })
 
       if (['element', 'object'].indexOf(type) !== -1) {
-        itValidatesTheProperty(ctx, false)
+        itValidatesTheProperty(ctx, true)
       } else {
-        itValidatesTheProperty(ctx, false, warningMessage)
+        itValidatesTheProperty(ctx, true, warningMessage)
       }
     })
 
-    describe('with function value', function () {
+    describe('updated with function value', function () {
       beforeEach(function () {
         ctx.instance.set('bar', () => {})
       })
 
       if (type === 'func') {
-        itValidatesTheProperty(ctx, false)
+        itValidatesTheProperty(ctx, true)
       } else {
-        itValidatesTheProperty(ctx, false, warningMessage)
+        itValidatesTheProperty(ctx, true, warningMessage)
       }
     })
 
-    describe('with null value', function () {
+    describe('updated with null value', function () {
       beforeEach(function () {
         ctx.instance.set('bar', null)
       })
 
       if (type === 'null') {
-        itValidatesTheProperty(ctx, false)
+        itValidatesTheProperty(ctx, true)
       } else {
-        itValidatesTheProperty(ctx, false, warningMessage)
+        itValidatesTheProperty(ctx, true, warningMessage)
       }
     })
 
-    describe('with number value', function () {
+    describe('updated with number value', function () {
       beforeEach(function () {
         ctx.instance.set('bar', 2)
       })
 
       if (type === 'number') {
-        itValidatesTheProperty(ctx, false)
+        itValidatesTheProperty(ctx, true)
       } else {
-        itValidatesTheProperty(ctx, false, warningMessage)
+        itValidatesTheProperty(ctx, true, warningMessage)
       }
     })
 
-    describe('with object value', function () {
+    describe('updated with object value', function () {
       beforeEach(function () {
         ctx.instance.set('bar', {})
       })
 
       if (type === 'object') {
-        itValidatesTheProperty(ctx, false)
+        itValidatesTheProperty(ctx, true)
       } else {
-        itValidatesTheProperty(ctx, false, warningMessage)
+        itValidatesTheProperty(ctx, true, warningMessage)
       }
     })
 
-    describe('with string value', function () {
+    describe('updated with string value', function () {
       beforeEach(function () {
         ctx.instance.set('bar', 'spam')
       })
 
       if (type === 'string') {
-        itValidatesTheProperty(ctx, false)
+        itValidatesTheProperty(ctx, true)
       } else {
-        itValidatesTheProperty(ctx, false, warningMessage)
+        itValidatesTheProperty(ctx, true, warningMessage)
       }
     })
 
-    describe('with symbol value', function () {
+    describe('updated with symbol value', function () {
       beforeEach(function () {
         ctx.instance.set('bar', Symbol())
       })
 
       if (['object', 'symbol'].indexOf(type) !== -1) {
-        itValidatesTheProperty(ctx, false)
+        itValidatesTheProperty(ctx, true)
       } else {
-        itValidatesTheProperty(ctx, false, warningMessage)
+        itValidatesTheProperty(ctx, true, warningMessage)
       }
     })
   })
@@ -279,6 +303,19 @@ export function itValidatesTheProperty (ctx, throwErrors, ...warningMessages) {
   })
 
   if (throwErrors) {
+    if (warningMessages.length > 0) {
+      it('should throw errors', function () {
+        expect(logger.throwError).to.have.callCount(warningMessages.length)
+        warningMessages.forEach((msg) => {
+          expect(logger.throwError).to.have.been.calledWith(msg)
+        })
+      })
+    } else {
+      it('should not throw errors', function () {
+        expect(logger.throwError).to.have.callCount(0)
+      })
+    }
+
     it('should not log warning', function () {
       expect(Logger.warn).to.have.callCount(0)
     })
@@ -295,6 +332,10 @@ export function itValidatesTheProperty (ctx, throwErrors, ...warningMessages) {
         expect(Logger.warn).to.have.callCount(0)
       })
     }
+
+    it('should not throw errors', function () {
+      expect(logger.throwError).to.have.callCount(0)
+    })
   }
 }
 
@@ -303,6 +344,7 @@ export function itValidatesTheProperty (ctx, throwErrors, ...warningMessages) {
  * @param {*} sandbox - the sinon sandbox instance to use to stub/spy
  */
 export function spyOnValidateMethods (sandbox) {
+  sandbox.stub(logger, 'throwError')
   sandbox.spy(helpers, 'validatePropTypes')
   sandbox.spy(helpers, 'validateProperty')
   sandbox.stub(Logger, 'warn')

--- a/tests/helpers/validator.js
+++ b/tests/helpers/validator.js
@@ -5,22 +5,17 @@ import {expect} from 'chai'
 import Ember from 'ember'
 const {Logger} = Ember
 import {after, before, beforeEach, describe, it} from 'mocha'
-import sinon from 'sinon'
 
-import {helpers} from 'ember-prop-types/mixins/prop-types'
+import {helpers, settings} from 'ember-prop-types/mixins/prop-types'
 import logger from 'ember-prop-types/utils/logger'
 
 export function itValidatesOnUpdate (ctx, type, warningMessage) {
   describe('when throwErrors set to false', function () {
-    let getSettingsStub
+    let throwErrorsOriginalValue
 
     before(function () {
-      getSettingsStub = sinon.stub(helpers, 'getSettings', () => {
-        return {
-          throwErrors: false,
-          validateOnUpdate: true
-        }
-      })
+      throwErrorsOriginalValue = settings.throwErrors
+      settings.throwErrors = false
     })
 
     beforeEach(function () {
@@ -29,7 +24,7 @@ export function itValidatesOnUpdate (ctx, type, warningMessage) {
     })
 
     after(function () {
-      getSettingsStub.restore()
+      settings.throwErrors = throwErrorsOriginalValue
     })
 
     describe('updated with array value', function () {
@@ -142,15 +137,11 @@ export function itValidatesOnUpdate (ctx, type, warningMessage) {
   })
 
   describe('when throwErrors set to true', function () {
-    let getSettingsStub
+    let throwErrorsOriginalValue
 
     before(function () {
-      getSettingsStub = sinon.stub(helpers, 'getSettings', () => {
-        return {
-          throwErrors: true,
-          validateOnUpdate: true
-        }
-      })
+      throwErrorsOriginalValue = settings.throwErrors
+      settings.throwErrors = true
     })
 
     beforeEach(function () {
@@ -159,7 +150,7 @@ export function itValidatesOnUpdate (ctx, type, warningMessage) {
     })
 
     after(function () {
-      getSettingsStub.restore()
+      settings.throwErrors = throwErrorsOriginalValue
     })
 
     describe('updated with array value', function () {

--- a/tests/unit/prop-types/any-test.js
+++ b/tests/unit/prop-types/any-test.js
@@ -49,7 +49,7 @@ describe('Unit / validator / PropTypes.any', function () {
         ctx.instance = Foo.create({bar: []})
       })
 
-      itValidatesTheProperty(ctx)
+      itValidatesTheProperty(ctx, false)
 
       describe('when updated with array value', function () {
         beforeEach(function () {
@@ -57,7 +57,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', [])
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with boolean value', function () {
@@ -66,7 +66,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', false)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with null value', function () {
@@ -75,7 +75,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', null)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with number value', function () {
@@ -84,7 +84,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', 2)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with object value', function () {
@@ -93,7 +93,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', {})
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with string value', function () {
@@ -102,7 +102,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', 'baz')
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
     })
 
@@ -111,7 +111,7 @@ describe('Unit / validator / PropTypes.any', function () {
         ctx.instance = Foo.create({bar: true})
       })
 
-      itValidatesTheProperty(ctx)
+      itValidatesTheProperty(ctx, false)
 
       describe('when updated with array value', function () {
         beforeEach(function () {
@@ -119,7 +119,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', [])
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with boolean value', function () {
@@ -128,7 +128,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', false)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with null value', function () {
@@ -137,7 +137,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', null)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with number value', function () {
@@ -146,7 +146,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', 2)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with object value', function () {
@@ -155,7 +155,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', {})
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with string value', function () {
@@ -164,7 +164,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', 'baz')
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
     })
 
@@ -173,7 +173,7 @@ describe('Unit / validator / PropTypes.any', function () {
         ctx.instance = Foo.create({bar () {}})
       })
 
-      itValidatesTheProperty(ctx)
+      itValidatesTheProperty(ctx, false)
 
       describe('when updated with array value', function () {
         beforeEach(function () {
@@ -181,7 +181,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', [])
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with boolean value', function () {
@@ -190,7 +190,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', false)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with null value', function () {
@@ -199,7 +199,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', null)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with number value', function () {
@@ -208,7 +208,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', 2)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with object value', function () {
@@ -217,7 +217,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', {})
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with string value', function () {
@@ -226,7 +226,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', 'baz')
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
     })
 
@@ -235,7 +235,7 @@ describe('Unit / validator / PropTypes.any', function () {
         ctx.instance = Foo.create({bar: null})
       })
 
-      itValidatesTheProperty(ctx)
+      itValidatesTheProperty(ctx, false)
 
       describe('when updated with array value', function () {
         beforeEach(function () {
@@ -243,7 +243,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', [])
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with boolean value', function () {
@@ -252,7 +252,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', false)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with null value', function () {
@@ -261,7 +261,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', null)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with number value', function () {
@@ -270,7 +270,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', 2)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with object value', function () {
@@ -279,7 +279,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', {})
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with string value', function () {
@@ -288,7 +288,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', 'baz')
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
     })
 
@@ -297,7 +297,7 @@ describe('Unit / validator / PropTypes.any', function () {
         ctx.instance = Foo.create({bar: 1})
       })
 
-      itValidatesTheProperty(ctx)
+      itValidatesTheProperty(ctx, false)
 
       describe('when updated with array value', function () {
         beforeEach(function () {
@@ -305,7 +305,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', [])
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with boolean value', function () {
@@ -314,7 +314,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', false)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with null value', function () {
@@ -323,7 +323,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', null)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with number value', function () {
@@ -332,7 +332,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', 2)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with object value', function () {
@@ -341,7 +341,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', {})
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with string value', function () {
@@ -350,7 +350,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', 'baz')
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
     })
 
@@ -359,7 +359,7 @@ describe('Unit / validator / PropTypes.any', function () {
         ctx.instance = Foo.create({bar: {}})
       })
 
-      itValidatesTheProperty(ctx)
+      itValidatesTheProperty(ctx, false)
 
       describe('when updated with array value', function () {
         beforeEach(function () {
@@ -367,7 +367,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', [])
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with boolean value', function () {
@@ -376,7 +376,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', false)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with null value', function () {
@@ -385,7 +385,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', null)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with number value', function () {
@@ -394,7 +394,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', 2)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with object value', function () {
@@ -403,7 +403,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', {})
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with string value', function () {
@@ -412,7 +412,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', 'baz')
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
     })
 
@@ -421,7 +421,7 @@ describe('Unit / validator / PropTypes.any', function () {
         ctx.instance = Foo.create({bar: 'test'})
       })
 
-      itValidatesTheProperty(ctx)
+      itValidatesTheProperty(ctx, false)
 
       describe('when updated with array value', function () {
         beforeEach(function () {
@@ -429,7 +429,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', [])
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with boolean value', function () {
@@ -438,7 +438,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', false)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with null value', function () {
@@ -447,7 +447,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', null)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with number value', function () {
@@ -456,7 +456,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', 2)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with object value', function () {
@@ -465,7 +465,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', {})
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with string value', function () {
@@ -474,7 +474,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', 'baz')
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
     })
 
@@ -483,7 +483,7 @@ describe('Unit / validator / PropTypes.any', function () {
         ctx.instance = Foo.create()
       })
 
-      itValidatesTheProperty(ctx, 'Missing required property bar')
+      itValidatesTheProperty(ctx, false, 'Missing required property bar')
 
       describe('when updated with array value', function () {
         beforeEach(function () {
@@ -491,7 +491,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', [])
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with boolean value', function () {
@@ -500,7 +500,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', false)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with null value', function () {
@@ -509,7 +509,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', null)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with number value', function () {
@@ -518,7 +518,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', 2)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with object value', function () {
@@ -527,7 +527,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', {})
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with string value', function () {
@@ -536,7 +536,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', 'baz')
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
     })
   })
@@ -556,7 +556,7 @@ describe('Unit / validator / PropTypes.any', function () {
         ctx.instance = Foo.create({bar: []})
       })
 
-      itValidatesTheProperty(ctx)
+      itValidatesTheProperty(ctx, false)
 
       describe('when updated with array value', function () {
         beforeEach(function () {
@@ -564,7 +564,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', [])
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with boolean value', function () {
@@ -573,7 +573,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', false)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with null value', function () {
@@ -582,7 +582,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', null)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with number value', function () {
@@ -591,7 +591,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', 2)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with object value', function () {
@@ -600,7 +600,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', {})
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with string value', function () {
@@ -609,7 +609,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', 'baz')
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
     })
 
@@ -618,7 +618,7 @@ describe('Unit / validator / PropTypes.any', function () {
         ctx.instance = Foo.create({bar: true})
       })
 
-      itValidatesTheProperty(ctx)
+      itValidatesTheProperty(ctx, false)
 
       describe('when updated with array value', function () {
         beforeEach(function () {
@@ -626,7 +626,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', [])
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with boolean value', function () {
@@ -635,7 +635,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', false)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with null value', function () {
@@ -644,7 +644,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', null)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with number value', function () {
@@ -653,7 +653,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', 2)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with object value', function () {
@@ -662,7 +662,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', {})
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with string value', function () {
@@ -671,7 +671,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', 'baz')
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
     })
 
@@ -680,7 +680,7 @@ describe('Unit / validator / PropTypes.any', function () {
         ctx.instance = Foo.create({bar () {}})
       })
 
-      itValidatesTheProperty(ctx)
+      itValidatesTheProperty(ctx, false)
 
       describe('when updated with array value', function () {
         beforeEach(function () {
@@ -688,7 +688,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', [])
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with boolean value', function () {
@@ -697,7 +697,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', false)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with null value', function () {
@@ -706,7 +706,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', null)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with number value', function () {
@@ -715,7 +715,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', 2)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with object value', function () {
@@ -724,7 +724,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', {})
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with string value', function () {
@@ -733,7 +733,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', 'baz')
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
     })
 
@@ -742,7 +742,7 @@ describe('Unit / validator / PropTypes.any', function () {
         ctx.instance = Foo.create({bar: null})
       })
 
-      itValidatesTheProperty(ctx)
+      itValidatesTheProperty(ctx, false)
 
       describe('when updated with array value', function () {
         beforeEach(function () {
@@ -750,7 +750,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', [])
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with boolean value', function () {
@@ -759,7 +759,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', false)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with null value', function () {
@@ -768,7 +768,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', null)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with number value', function () {
@@ -777,7 +777,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', 2)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with object value', function () {
@@ -786,7 +786,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', {})
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with string value', function () {
@@ -795,7 +795,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', 'baz')
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
     })
 
@@ -804,7 +804,7 @@ describe('Unit / validator / PropTypes.any', function () {
         ctx.instance = Foo.create({bar: 1})
       })
 
-      itValidatesTheProperty(ctx)
+      itValidatesTheProperty(ctx, false)
 
       describe('when updated with array value', function () {
         beforeEach(function () {
@@ -812,7 +812,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', [])
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with boolean value', function () {
@@ -821,7 +821,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', false)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with null value', function () {
@@ -830,7 +830,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', null)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with number value', function () {
@@ -839,7 +839,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', 2)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with object value', function () {
@@ -848,7 +848,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', {})
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with string value', function () {
@@ -857,7 +857,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', 'baz')
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
     })
 
@@ -866,7 +866,7 @@ describe('Unit / validator / PropTypes.any', function () {
         ctx.instance = Foo.create({bar: {}})
       })
 
-      itValidatesTheProperty(ctx)
+      itValidatesTheProperty(ctx, false)
 
       describe('when updated with array value', function () {
         beforeEach(function () {
@@ -874,7 +874,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', [])
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with boolean value', function () {
@@ -883,7 +883,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', false)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with null value', function () {
@@ -892,7 +892,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', null)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with number value', function () {
@@ -901,7 +901,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', 2)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with object value', function () {
@@ -910,7 +910,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', {})
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with string value', function () {
@@ -919,7 +919,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', 'baz')
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
     })
 
@@ -928,7 +928,7 @@ describe('Unit / validator / PropTypes.any', function () {
         ctx.instance = Foo.create({bar: 'test'})
       })
 
-      itValidatesTheProperty(ctx)
+      itValidatesTheProperty(ctx, false)
 
       describe('when updated with array value', function () {
         beforeEach(function () {
@@ -936,7 +936,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', [])
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with boolean value', function () {
@@ -945,7 +945,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', false)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with null value', function () {
@@ -954,7 +954,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', null)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with number value', function () {
@@ -963,7 +963,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', 2)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with object value', function () {
@@ -972,7 +972,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', {})
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with string value', function () {
@@ -981,7 +981,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', 'baz')
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
     })
 
@@ -990,7 +990,7 @@ describe('Unit / validator / PropTypes.any', function () {
         ctx.instance = Foo.create()
       })
 
-      itValidatesTheProperty(ctx)
+      itValidatesTheProperty(ctx, false)
 
       describe('when updated with array value', function () {
         beforeEach(function () {
@@ -998,7 +998,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', [])
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with boolean value', function () {
@@ -1007,7 +1007,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', false)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with null value', function () {
@@ -1016,7 +1016,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', null)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with number value', function () {
@@ -1025,7 +1025,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', 2)
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with object value', function () {
@@ -1034,7 +1034,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', {})
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when updated with string value', function () {
@@ -1043,7 +1043,7 @@ describe('Unit / validator / PropTypes.any', function () {
           ctx.instance.set('bar', 'baz')
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
     })
   })

--- a/tests/unit/prop-types/array-of-test.js
+++ b/tests/unit/prop-types/array-of-test.js
@@ -96,7 +96,7 @@ describe('Unit / validator / PropTypes.arrayOf', function () {
           ctx.instance = Foo.create({bar: ['alpha', 'bravo']})
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when initialized with array of booleans', function () {
@@ -106,6 +106,7 @@ describe('Unit / validator / PropTypes.arrayOf', function () {
 
         itValidatesTheProperty(
           ctx,
+          false,
           'Expected property bar[0] to be a string',
           'Expected property bar to be an array of type string'
         )
@@ -118,6 +119,7 @@ describe('Unit / validator / PropTypes.arrayOf', function () {
 
         itValidatesTheProperty(
           ctx,
+          false,
           'Expected property bar[1] to be a string',
           'Expected property bar to be an array of type string'
         )
@@ -128,7 +130,7 @@ describe('Unit / validator / PropTypes.arrayOf', function () {
           ctx.instance = Foo.create()
         })
 
-        itValidatesTheProperty(ctx, 'Missing required property bar')
+        itValidatesTheProperty(ctx, false, 'Missing required property bar')
       })
     })
 
@@ -147,7 +149,7 @@ describe('Unit / validator / PropTypes.arrayOf', function () {
           ctx.instance = Foo.create({bar: ['alpha', 'bravo']})
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when initialized with array of booleans', function () {
@@ -157,6 +159,7 @@ describe('Unit / validator / PropTypes.arrayOf', function () {
 
         itValidatesTheProperty(
           ctx,
+          false,
           'Expected property bar[0] to be a string',
           'Expected property bar to be an array of type string'
         )
@@ -169,6 +172,7 @@ describe('Unit / validator / PropTypes.arrayOf', function () {
 
         itValidatesTheProperty(
           ctx,
+          false,
           'Expected property bar[1] to be a string',
           'Expected property bar to be an array of type string'
         )
@@ -179,7 +183,7 @@ describe('Unit / validator / PropTypes.arrayOf', function () {
           ctx.instance = Foo.create()
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
     })
   })
@@ -203,7 +207,7 @@ describe('Unit / validator / PropTypes.arrayOf', function () {
           ctx.instance = Foo.create({bar: [{fizz: 'alpha', bang: 1}, {fizz: 'bravo', bang: 2}]})
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when initialized with array of invalid shapes', function () {
@@ -213,6 +217,7 @@ describe('Unit / validator / PropTypes.arrayOf', function () {
 
         itValidatesTheProperty(
           ctx,
+          false,
           'Property bar[0] has an unknown key: foo',
           'Property bar[0] does not match the given shape',
           'Expected property bar to be an array of type shape'
@@ -226,6 +231,7 @@ describe('Unit / validator / PropTypes.arrayOf', function () {
 
         itValidatesTheProperty(
           ctx,
+          false,
           'Property bar[1] has an unknown key: foo',
           'Property bar[1] does not match the given shape',
           'Expected property bar to be an array of type shape'
@@ -237,7 +243,7 @@ describe('Unit / validator / PropTypes.arrayOf', function () {
           ctx.instance = Foo.create()
         })
 
-        itValidatesTheProperty(ctx, 'Missing required property bar')
+        itValidatesTheProperty(ctx, false, 'Missing required property bar')
       })
     })
 
@@ -259,7 +265,7 @@ describe('Unit / validator / PropTypes.arrayOf', function () {
           ctx.instance = Foo.create({bar: [{fizz: 'alpha', bang: 1}, {fizz: 'bravo', bang: 2}]})
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
 
       describe('when initialized with array of invalid shapes', function () {
@@ -269,6 +275,7 @@ describe('Unit / validator / PropTypes.arrayOf', function () {
 
         itValidatesTheProperty(
           ctx,
+          false,
           'Property bar[0] has an unknown key: foo',
           'Property bar[0] does not match the given shape',
           'Expected property bar to be an array of type shape'
@@ -282,6 +289,7 @@ describe('Unit / validator / PropTypes.arrayOf', function () {
 
         itValidatesTheProperty(
           ctx,
+          false,
           'Property bar[1] has an unknown key: foo',
           'Property bar[1] does not match the given shape',
           'Expected property bar to be an array of type shape'
@@ -293,7 +301,7 @@ describe('Unit / validator / PropTypes.arrayOf', function () {
           ctx.instance = Foo.create()
         })
 
-        itValidatesTheProperty(ctx)
+        itValidatesTheProperty(ctx, false)
       })
     })
   })

--- a/tests/unit/prop-types/array-test.js
+++ b/tests/unit/prop-types/array-test.js
@@ -2,11 +2,15 @@
  * Unit test for the PropTypes.array validator
  */
 import Ember from 'ember'
-const {Logger} = Ember
 import {afterEach, beforeEach, describe} from 'mocha'
 import sinon from 'sinon'
 
-import {itValidatesTheProperty, spyOnValidateMethods} from 'dummy/tests/helpers/validator'
+import {
+  itValidatesOnUpdate,
+  itValidatesTheProperty,
+  spyOnValidateMethods
+} from 'dummy/tests/helpers/validator'
+
 import PropTypesMixin, {PropTypes} from 'ember-prop-types/mixins/prop-types'
 
 const requiredDef = {
@@ -48,61 +52,8 @@ describe('Unit / validator / PropTypes.array', function () {
         ctx.instance = Foo.create({bar: []})
       })
 
-      itValidatesTheProperty(ctx)
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx)
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'spam')
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
-      })
+      itValidatesTheProperty(ctx, false)
+      itValidatesOnUpdate(ctx, 'array', 'Expected property bar to be an array')
     })
 
     describe('when initialized with number value', function () {
@@ -110,61 +61,8 @@ describe('Unit / validator / PropTypes.array', function () {
         ctx.instance = Foo.create({bar: 1})
       })
 
-      itValidatesTheProperty(ctx, 'Expected property bar to be an array')
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx)
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'spam')
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
-      })
+      itValidatesTheProperty(ctx, false, 'Expected property bar to be an array')
+      itValidatesOnUpdate(ctx, 'array', 'Expected property bar to be an array')
     })
 
     describe('when initialized without value', function () {
@@ -172,61 +70,8 @@ describe('Unit / validator / PropTypes.array', function () {
         ctx.instance = Foo.create()
       })
 
-      itValidatesTheProperty(ctx, 'Missing required property bar')
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx)
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'spam')
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
-      })
+      itValidatesTheProperty(ctx, false, 'Missing required property bar')
+      itValidatesOnUpdate(ctx, 'array', 'Expected property bar to be an array')
     })
   })
 
@@ -245,61 +90,8 @@ describe('Unit / validator / PropTypes.array', function () {
         ctx.instance = Foo.create({bar: []})
       })
 
-      itValidatesTheProperty(ctx)
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx)
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'spam')
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
-      })
+      itValidatesTheProperty(ctx, false)
+      itValidatesOnUpdate(ctx, 'array', 'Expected property bar to be an array')
     })
 
     describe('when initialized with number value', function () {
@@ -307,61 +99,8 @@ describe('Unit / validator / PropTypes.array', function () {
         ctx.instance = Foo.create({bar: 1})
       })
 
-      itValidatesTheProperty(ctx, 'Expected property bar to be an array')
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx)
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'spam')
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
-      })
+      itValidatesTheProperty(ctx, false, 'Expected property bar to be an array')
+      itValidatesOnUpdate(ctx, 'array', 'Expected property bar to be an array')
     })
 
     describe('when initialized without value', function () {
@@ -369,61 +108,8 @@ describe('Unit / validator / PropTypes.array', function () {
         ctx.instance = Foo.create()
       })
 
-      itValidatesTheProperty(ctx)
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx)
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'spam')
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an array')
-      })
+      itValidatesTheProperty(ctx, false)
+      itValidatesOnUpdate(ctx, 'array', 'Expected property bar to be an array')
     })
   })
 })

--- a/tests/unit/prop-types/bool-test.js
+++ b/tests/unit/prop-types/bool-test.js
@@ -2,11 +2,15 @@
  * Unit test for the PropTypes.bool validator
  */
 import Ember from 'ember'
-const {Logger} = Ember
 import {afterEach, beforeEach, describe} from 'mocha'
 import sinon from 'sinon'
 
-import {itValidatesTheProperty, spyOnValidateMethods} from 'dummy/tests/helpers/validator'
+import {
+  itValidatesOnUpdate,
+  itValidatesTheProperty,
+  spyOnValidateMethods
+} from 'dummy/tests/helpers/validator'
+
 import PropTypesMixin, {PropTypes} from 'ember-prop-types/mixins/prop-types'
 
 const requiredDef = {
@@ -48,61 +52,8 @@ describe('Unit / validator / PropTypes.bool', function () {
         ctx.instance = Foo.create({bar: true})
       })
 
-      itValidatesTheProperty(ctx)
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx)
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'baz')
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
-      })
+      itValidatesTheProperty(ctx, false)
+      itValidatesOnUpdate(ctx, 'bool', 'Expected property bar to be a boolean')
     })
 
     describe('when initialized with number value', function () {
@@ -110,61 +61,8 @@ describe('Unit / validator / PropTypes.bool', function () {
         ctx.instance = Foo.create({bar: 1})
       })
 
-      itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx)
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'baz')
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
-      })
+      itValidatesTheProperty(ctx, false, 'Expected property bar to be a boolean')
+      itValidatesOnUpdate(ctx, 'bool', 'Expected property bar to be a boolean')
     })
 
     describe('when initialized without value', function () {
@@ -172,61 +70,8 @@ describe('Unit / validator / PropTypes.bool', function () {
         ctx.instance = Foo.create()
       })
 
-      itValidatesTheProperty(ctx, 'Missing required property bar')
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx)
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'baz')
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
-      })
+      itValidatesTheProperty(ctx, false, 'Missing required property bar')
+      itValidatesOnUpdate(ctx, 'bool', 'Expected property bar to be a boolean')
     })
   })
 
@@ -245,61 +90,8 @@ describe('Unit / validator / PropTypes.bool', function () {
         ctx.instance = Foo.create({bar: true})
       })
 
-      itValidatesTheProperty(ctx)
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx)
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'baz')
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
-      })
+      itValidatesTheProperty(ctx, false)
+      itValidatesOnUpdate(ctx, 'bool', 'Expected property bar to be a boolean')
     })
 
     describe('when initialized with number value', function () {
@@ -307,61 +99,8 @@ describe('Unit / validator / PropTypes.bool', function () {
         ctx.instance = Foo.create({bar: 1})
       })
 
-      itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx)
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'baz')
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
-      })
+      itValidatesTheProperty(ctx, false, 'Expected property bar to be a boolean')
+      itValidatesOnUpdate(ctx, 'bool', 'Expected property bar to be a boolean')
     })
 
     describe('when initialized without value', function () {
@@ -369,61 +108,8 @@ describe('Unit / validator / PropTypes.bool', function () {
         ctx.instance = Foo.create()
       })
 
-      itValidatesTheProperty(ctx)
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx)
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'baz')
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a boolean')
-      })
+      itValidatesTheProperty(ctx, false)
+      itValidatesOnUpdate(ctx, 'bool', 'Expected property bar to be a boolean')
     })
   })
 })

--- a/tests/unit/prop-types/element-test.js
+++ b/tests/unit/prop-types/element-test.js
@@ -2,11 +2,15 @@
  * Unit test for the PropTypes.element validator
  */
 import Ember from 'ember'
-const {Logger} = Ember
 import {afterEach, beforeEach, describe} from 'mocha'
 import sinon from 'sinon'
 
-import {itValidatesTheProperty, spyOnValidateMethods} from 'dummy/tests/helpers/validator'
+import {
+  itValidatesOnUpdate,
+  itValidatesTheProperty,
+  spyOnValidateMethods
+} from 'dummy/tests/helpers/validator'
+
 import PropTypesMixin, {PropTypes} from 'ember-prop-types/mixins/prop-types'
 
 const requiredDef = {
@@ -48,79 +52,8 @@ describe('Unit / validator / PropTypes.element', function () {
         ctx.instance = Foo.create({bar: document.createElement('div')})
       })
 
-      itValidatesTheProperty(ctx)
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
-      })
-
-      describe('when updated with element value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', document.createElement('span'))
-        })
-
-        itValidatesTheProperty(ctx)
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'spam')
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
-      })
-
-      describe('when updated with symbol value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', Symbol())
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
-      })
+      itValidatesTheProperty(ctx, false)
+      itValidatesOnUpdate(ctx, 'element', 'Expected property bar to be an element')
     })
 
     describe('when initialized with string value', function () {
@@ -128,79 +61,8 @@ describe('Unit / validator / PropTypes.element', function () {
         ctx.instance = Foo.create({bar: 'baz'})
       })
 
-      itValidatesTheProperty(ctx, 'Expected property bar to be an element')
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
-      })
-
-      describe('when updated with element value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', document.createElement('span'))
-        })
-
-        itValidatesTheProperty(ctx)
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'spam')
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
-      })
-
-      describe('when updated with symbol value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', Symbol())
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
-      })
+      itValidatesTheProperty(ctx, false, 'Expected property bar to be an element')
+      itValidatesOnUpdate(ctx, 'element', 'Expected property bar to be an element')
     })
 
     describe('when initialized without value', function () {
@@ -208,79 +70,8 @@ describe('Unit / validator / PropTypes.element', function () {
         ctx.instance = Foo.create()
       })
 
-      itValidatesTheProperty(ctx, 'Missing required property bar')
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
-      })
-
-      describe('when updated with element value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', document.createElement('span'))
-        })
-
-        itValidatesTheProperty(ctx)
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'spam')
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
-      })
-
-      describe('when updated with symbol value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', Symbol())
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
-      })
+      itValidatesTheProperty(ctx, false, 'Missing required property bar')
+      itValidatesOnUpdate(ctx, 'element', 'Expected property bar to be an element')
     })
   })
 
@@ -299,79 +90,8 @@ describe('Unit / validator / PropTypes.element', function () {
         ctx.instance = Foo.create({bar: document.createElement('div')})
       })
 
-      itValidatesTheProperty(ctx)
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
-      })
-
-      describe('when updated with element value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', document.createElement('span'))
-        })
-
-        itValidatesTheProperty(ctx)
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'spam')
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
-      })
-
-      describe('when updated with symbol value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', Symbol())
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
-      })
+      itValidatesTheProperty(ctx, false)
+      itValidatesOnUpdate(ctx, 'element', 'Expected property bar to be an element')
     })
 
     describe('when initialized with string value', function () {
@@ -379,79 +99,8 @@ describe('Unit / validator / PropTypes.element', function () {
         ctx.instance = Foo.create({bar: 'baz'})
       })
 
-      itValidatesTheProperty(ctx, 'Expected property bar to be an element')
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
-      })
-
-      describe('when updated with element value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', document.createElement('span'))
-        })
-
-        itValidatesTheProperty(ctx)
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'spam')
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
-      })
-
-      describe('when updated with symbol value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', Symbol())
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
-      })
+      itValidatesTheProperty(ctx, false, 'Expected property bar to be an element')
+      itValidatesOnUpdate(ctx, 'element', 'Expected property bar to be an element')
     })
 
     describe('when initialized without value', function () {
@@ -459,79 +108,8 @@ describe('Unit / validator / PropTypes.element', function () {
         ctx.instance = Foo.create()
       })
 
-      itValidatesTheProperty(ctx)
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
-      })
-
-      describe('when updated with element value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', document.createElement('span'))
-        })
-
-        itValidatesTheProperty(ctx)
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'spam')
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
-      })
-
-      describe('when updated with symbol value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', Symbol())
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an element')
-      })
+      itValidatesTheProperty(ctx, false)
+      itValidatesOnUpdate(ctx, 'element', 'Expected property bar to be an element')
     })
   })
 })

--- a/tests/unit/prop-types/ember-object-test.js
+++ b/tests/unit/prop-types/ember-object-test.js
@@ -47,7 +47,7 @@ describe('Unit / validator / PropTypes.EmberObject', function () {
         ctx.instance = Foo.create({bar: Ember.Object.create({})})
       })
 
-      itValidatesTheProperty(ctx)
+      itValidatesTheProperty(ctx, false)
     })
 
     describe('when initialized with POJO value', function () {
@@ -55,7 +55,7 @@ describe('Unit / validator / PropTypes.EmberObject', function () {
         ctx.instance = Foo.create({bar: {}})
       })
 
-      itValidatesTheProperty(ctx, 'Expected property bar to be an Ember.Object')
+      itValidatesTheProperty(ctx, false, 'Expected property bar to be an Ember.Object')
     })
 
     describe('when initialized without value', function () {
@@ -63,7 +63,7 @@ describe('Unit / validator / PropTypes.EmberObject', function () {
         ctx.instance = Foo.create()
       })
 
-      itValidatesTheProperty(ctx, 'Missing required property bar')
+      itValidatesTheProperty(ctx, false, 'Missing required property bar')
     })
   })
 
@@ -82,7 +82,7 @@ describe('Unit / validator / PropTypes.EmberObject', function () {
         ctx.instance = Foo.create({bar: Ember.Object.create({})})
       })
 
-      itValidatesTheProperty(ctx)
+      itValidatesTheProperty(ctx, false)
     })
 
     describe('when initialized with POJO value', function () {
@@ -90,7 +90,7 @@ describe('Unit / validator / PropTypes.EmberObject', function () {
         ctx.instance = Foo.create({bar: {}})
       })
 
-      itValidatesTheProperty(ctx, 'Expected property bar to be an Ember.Object')
+      itValidatesTheProperty(ctx, false, 'Expected property bar to be an Ember.Object')
     })
 
     describe('when initialized without value', function () {
@@ -98,7 +98,7 @@ describe('Unit / validator / PropTypes.EmberObject', function () {
         ctx.instance = Foo.create()
       })
 
-      itValidatesTheProperty(ctx)
+      itValidatesTheProperty(ctx, false)
     })
   })
 })

--- a/tests/unit/prop-types/func-test.js
+++ b/tests/unit/prop-types/func-test.js
@@ -5,7 +5,12 @@ import Ember from 'ember'
 import {afterEach, beforeEach, describe} from 'mocha'
 import sinon from 'sinon'
 
-import {itValidatesTheProperty, spyOnValidateMethods} from 'dummy/tests/helpers/validator'
+import {
+  itValidatesOnUpdate,
+  itValidatesTheProperty,
+  spyOnValidateMethods
+} from 'dummy/tests/helpers/validator'
+
 import PropTypesMixin, {PropTypes} from 'ember-prop-types/mixins/prop-types'
 
 const requiredDef = {
@@ -47,7 +52,8 @@ describe('Unit / validator / PropTypes.func', function () {
         ctx.instance = Foo.create({bar () {}})
       })
 
-      itValidatesTheProperty(ctx)
+      itValidatesTheProperty(ctx, false)
+      itValidatesOnUpdate(ctx, 'func', 'Expected property bar to be a function')
     })
 
     describe('when initialized with number value', function () {
@@ -55,7 +61,8 @@ describe('Unit / validator / PropTypes.func', function () {
         ctx.instance = Foo.create({bar: 1})
       })
 
-      itValidatesTheProperty(ctx, 'Expected property bar to be a function')
+      itValidatesTheProperty(ctx, false, 'Expected property bar to be a function')
+      itValidatesOnUpdate(ctx, 'func', 'Expected property bar to be a function')
     })
 
     describe('when initialized without value', function () {
@@ -63,7 +70,8 @@ describe('Unit / validator / PropTypes.func', function () {
         ctx.instance = Foo.create()
       })
 
-      itValidatesTheProperty(ctx, 'Missing required property bar')
+      itValidatesTheProperty(ctx, false, 'Missing required property bar')
+      itValidatesOnUpdate(ctx, 'func', 'Expected property bar to be a function')
     })
   })
 
@@ -82,7 +90,8 @@ describe('Unit / validator / PropTypes.func', function () {
         ctx.instance = Foo.create({bar () {}})
       })
 
-      itValidatesTheProperty(ctx)
+      itValidatesTheProperty(ctx, false)
+      itValidatesOnUpdate(ctx, 'func', 'Expected property bar to be a function')
     })
 
     describe('when initialized with number value', function () {
@@ -90,7 +99,8 @@ describe('Unit / validator / PropTypes.func', function () {
         ctx.instance = Foo.create({bar: 1})
       })
 
-      itValidatesTheProperty(ctx, 'Expected property bar to be a function')
+      itValidatesTheProperty(ctx, false, 'Expected property bar to be a function')
+      itValidatesOnUpdate(ctx, 'func', 'Expected property bar to be a function')
     })
 
     describe('when initialized without value', function () {
@@ -98,7 +108,8 @@ describe('Unit / validator / PropTypes.func', function () {
         ctx.instance = Foo.create()
       })
 
-      itValidatesTheProperty(ctx)
+      itValidatesTheProperty(ctx, false)
+      itValidatesOnUpdate(ctx, 'func', 'Expected property bar to be a function')
     })
   })
 })

--- a/tests/unit/prop-types/instance-of-test.js
+++ b/tests/unit/prop-types/instance-of-test.js
@@ -51,7 +51,7 @@ describe('Unit / validator / PropTypes.instanceOf', function () {
         ctx.instance = Foo.create({bar: new Classy()})
       })
 
-      itValidatesTheProperty(ctx)
+      itValidatesTheProperty(ctx, false)
     })
 
     describe('when initialized with non-Classy instance', function () {
@@ -59,7 +59,7 @@ describe('Unit / validator / PropTypes.instanceOf', function () {
         ctx.instance = Foo.create({bar: 1})
       })
 
-      itValidatesTheProperty(ctx, 'Expected property bar to be an instance of Classy')
+      itValidatesTheProperty(ctx, false, 'Expected property bar to be an instance of Classy')
     })
 
     describe('when initialized without value', function () {
@@ -67,7 +67,7 @@ describe('Unit / validator / PropTypes.instanceOf', function () {
         ctx.instance = Foo.create()
       })
 
-      itValidatesTheProperty(ctx, 'Missing required property bar')
+      itValidatesTheProperty(ctx, false, 'Missing required property bar')
     })
   })
 
@@ -86,7 +86,7 @@ describe('Unit / validator / PropTypes.instanceOf', function () {
         ctx.instance = Foo.create({bar: new Classy()})
       })
 
-      itValidatesTheProperty(ctx)
+      itValidatesTheProperty(ctx, false)
     })
 
     describe('when initialized with non-Classy instance', function () {
@@ -94,7 +94,7 @@ describe('Unit / validator / PropTypes.instanceOf', function () {
         ctx.instance = Foo.create({bar: 1})
       })
 
-      itValidatesTheProperty(ctx, 'Expected property bar to be an instance of Classy')
+      itValidatesTheProperty(ctx, false, 'Expected property bar to be an instance of Classy')
     })
 
     describe('when initialized without value', function () {
@@ -102,7 +102,7 @@ describe('Unit / validator / PropTypes.instanceOf', function () {
         ctx.instance = Foo.create()
       })
 
-      itValidatesTheProperty(ctx)
+      itValidatesTheProperty(ctx, false)
     })
   })
 })

--- a/tests/unit/prop-types/null-test.js
+++ b/tests/unit/prop-types/null-test.js
@@ -2,11 +2,15 @@
  * Unit test for the PropTypes.null validator
  */
 import Ember from 'ember'
-const {Logger} = Ember
 import {afterEach, beforeEach, describe} from 'mocha'
 import sinon from 'sinon'
 
-import {itValidatesTheProperty, spyOnValidateMethods} from 'dummy/tests/helpers/validator'
+import {
+  itValidatesOnUpdate,
+  itValidatesTheProperty,
+  spyOnValidateMethods
+} from 'dummy/tests/helpers/validator'
+
 import PropTypesMixin, {PropTypes} from 'ember-prop-types/mixins/prop-types'
 
 const requiredDef = {
@@ -48,61 +52,8 @@ describe('Unit / validator / PropTypes.null', function () {
         ctx.instance = Foo.create({bar: null})
       })
 
-      itValidatesTheProperty(ctx)
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be null')
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be null')
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx)
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be null')
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be null')
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'spam')
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be null')
-      })
+      itValidatesTheProperty(ctx, false)
+      itValidatesOnUpdate(ctx, 'null', 'Expected property bar to be null')
     })
 
     describe('when initialized with number value', function () {
@@ -110,61 +61,8 @@ describe('Unit / validator / PropTypes.null', function () {
         ctx.instance = Foo.create({bar: 1})
       })
 
-      itValidatesTheProperty(ctx, 'Expected property bar to be null')
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be null')
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be null')
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx)
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be null')
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be null')
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'spam')
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be null')
-      })
+      itValidatesTheProperty(ctx, false, 'Expected property bar to be null')
+      itValidatesOnUpdate(ctx, 'null', 'Expected property bar to be null')
     })
 
     describe('when initialized without value', function () {
@@ -172,61 +70,8 @@ describe('Unit / validator / PropTypes.null', function () {
         ctx.instance = Foo.create()
       })
 
-      itValidatesTheProperty(ctx, 'Missing required property bar')
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be null')
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be null')
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx)
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be null')
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be null')
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'spam')
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be null')
-      })
+      itValidatesTheProperty(ctx, false, 'Missing required property bar')
+      itValidatesOnUpdate(ctx, 'null', 'Expected property bar to be null')
     })
   })
 
@@ -245,61 +90,8 @@ describe('Unit / validator / PropTypes.null', function () {
         ctx.instance = Foo.create({bar: null})
       })
 
-      itValidatesTheProperty(ctx)
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be null')
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be null')
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx)
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be null')
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be null')
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'spam')
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be null')
-      })
+      itValidatesTheProperty(ctx, false)
+      itValidatesOnUpdate(ctx, 'null', 'Expected property bar to be null')
     })
 
     describe('when initialized with number value', function () {
@@ -307,61 +99,8 @@ describe('Unit / validator / PropTypes.null', function () {
         ctx.instance = Foo.create({bar: 1})
       })
 
-      itValidatesTheProperty(ctx, 'Expected property bar to be null')
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be null')
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be null')
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx)
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be null')
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be null')
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'spam')
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be null')
-      })
+      itValidatesTheProperty(ctx, false, 'Expected property bar to be null')
+      itValidatesOnUpdate(ctx, 'null', 'Expected property bar to be null')
     })
 
     describe('when initialized without value', function () {
@@ -369,61 +108,8 @@ describe('Unit / validator / PropTypes.null', function () {
         ctx.instance = Foo.create()
       })
 
-      itValidatesTheProperty(ctx)
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be null')
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be null')
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx)
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be null')
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be null')
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'spam')
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be null')
-      })
+      itValidatesTheProperty(ctx, false)
+      itValidatesOnUpdate(ctx, 'null', 'Expected property bar to be null')
     })
   })
 })

--- a/tests/unit/prop-types/number-test.js
+++ b/tests/unit/prop-types/number-test.js
@@ -2,11 +2,15 @@
  * Unit test for the PropTypes.number validator
  */
 import Ember from 'ember'
-const {Logger} = Ember
 import {afterEach, beforeEach, describe} from 'mocha'
 import sinon from 'sinon'
 
-import {itValidatesTheProperty, spyOnValidateMethods} from 'dummy/tests/helpers/validator'
+import {
+  itValidatesOnUpdate,
+  itValidatesTheProperty,
+  spyOnValidateMethods
+} from 'dummy/tests/helpers/validator'
+
 import PropTypesMixin, {PropTypes} from 'ember-prop-types/mixins/prop-types'
 
 const requiredDef = {
@@ -48,61 +52,8 @@ describe('Unit / validator / PropTypes.number', function () {
         ctx.instance = Foo.create({bar: 1})
       })
 
-      itValidatesTheProperty(ctx)
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx)
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'spam')
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
-      })
+      itValidatesTheProperty(ctx, false)
+      itValidatesOnUpdate(ctx, 'number', 'Expected property bar to be a number')
     })
 
     describe('when initialized with string value', function () {
@@ -110,61 +61,8 @@ describe('Unit / validator / PropTypes.number', function () {
         ctx.instance = Foo.create({bar: 'baz'})
       })
 
-      itValidatesTheProperty(ctx, 'Expected property bar to be a number')
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx)
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'spam')
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
-      })
+      itValidatesTheProperty(ctx, false, 'Expected property bar to be a number')
+      itValidatesOnUpdate(ctx, 'number', 'Expected property bar to be a number')
     })
 
     describe('when initialized without value', function () {
@@ -172,61 +70,8 @@ describe('Unit / validator / PropTypes.number', function () {
         ctx.instance = Foo.create()
       })
 
-      itValidatesTheProperty(ctx, 'Missing required property bar')
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx)
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'spam')
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
-      })
+      itValidatesTheProperty(ctx, false, 'Missing required property bar')
+      itValidatesOnUpdate(ctx, 'number', 'Expected property bar to be a number')
     })
   })
 
@@ -245,61 +90,8 @@ describe('Unit / validator / PropTypes.number', function () {
         ctx.instance = Foo.create({bar: 1})
       })
 
-      itValidatesTheProperty(ctx)
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx)
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'spam')
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
-      })
+      itValidatesTheProperty(ctx, false)
+      itValidatesOnUpdate(ctx, 'number', 'Expected property bar to be a number')
     })
 
     describe('when initialized with string value', function () {
@@ -307,61 +99,8 @@ describe('Unit / validator / PropTypes.number', function () {
         ctx.instance = Foo.create({bar: 'baz'})
       })
 
-      itValidatesTheProperty(ctx, 'Expected property bar to be a number')
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx)
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'spam')
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
-      })
+      itValidatesTheProperty(ctx, false, 'Expected property bar to be a number')
+      itValidatesOnUpdate(ctx, 'number', 'Expected property bar to be a number')
     })
 
     describe('when initialized without value', function () {
@@ -369,61 +108,8 @@ describe('Unit / validator / PropTypes.number', function () {
         ctx.instance = Foo.create()
       })
 
-      itValidatesTheProperty(ctx)
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx)
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'spam')
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a number')
-      })
+      itValidatesTheProperty(ctx, false)
+      itValidatesOnUpdate(ctx, 'number', 'Expected property bar to be a number')
     })
   })
 })

--- a/tests/unit/prop-types/object-test.js
+++ b/tests/unit/prop-types/object-test.js
@@ -2,11 +2,15 @@
  * Unit test for the PropTypes.object validator
  */
 import Ember from 'ember'
-const {Logger} = Ember
 import {afterEach, beforeEach, describe} from 'mocha'
 import sinon from 'sinon'
 
-import {itValidatesTheProperty, spyOnValidateMethods} from 'dummy/tests/helpers/validator'
+import {
+  itValidatesOnUpdate,
+  itValidatesTheProperty,
+  spyOnValidateMethods
+} from 'dummy/tests/helpers/validator'
+
 import PropTypesMixin, {PropTypes} from 'ember-prop-types/mixins/prop-types'
 
 const requiredDef = {
@@ -48,61 +52,8 @@ describe('Unit / validator / PropTypes.object', function () {
         ctx.instance = Foo.create({bar: {}})
       })
 
-      itValidatesTheProperty(ctx)
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx)
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'baz')
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
-      })
+      itValidatesTheProperty(ctx, false)
+      itValidatesOnUpdate(ctx, 'object', 'Expected property bar to be an object')
     })
 
     describe('when initialized with number value', function () {
@@ -110,61 +61,8 @@ describe('Unit / validator / PropTypes.object', function () {
         ctx.instance = Foo.create({bar: 1})
       })
 
-      itValidatesTheProperty(ctx, 'Expected property bar to be an object')
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx)
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'baz')
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
-      })
+      itValidatesTheProperty(ctx, false, 'Expected property bar to be an object')
+      itValidatesOnUpdate(ctx, 'object', 'Expected property bar to be an object')
     })
 
     describe('when initialized without value', function () {
@@ -172,61 +70,8 @@ describe('Unit / validator / PropTypes.object', function () {
         ctx.instance = Foo.create()
       })
 
-      itValidatesTheProperty(ctx, 'Missing required property bar')
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx)
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'baz')
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
-      })
+      itValidatesTheProperty(ctx, false, 'Missing required property bar')
+      itValidatesOnUpdate(ctx, 'object', 'Expected property bar to be an object')
     })
   })
 
@@ -245,61 +90,8 @@ describe('Unit / validator / PropTypes.object', function () {
         ctx.instance = Foo.create({bar: {}})
       })
 
-      itValidatesTheProperty(ctx)
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx)
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'baz')
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
-      })
+      itValidatesTheProperty(ctx, false)
+      itValidatesOnUpdate(ctx, 'object', 'Expected property bar to be an object')
     })
 
     describe('when initialized with number value', function () {
@@ -307,61 +99,8 @@ describe('Unit / validator / PropTypes.object', function () {
         ctx.instance = Foo.create({bar: 1})
       })
 
-      itValidatesTheProperty(ctx, 'Expected property bar to be an object')
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx)
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'baz')
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
-      })
+      itValidatesTheProperty(ctx, false, 'Expected property bar to be an object')
+      itValidatesOnUpdate(ctx, 'object', 'Expected property bar to be an object')
     })
 
     describe('when initialized without value', function () {
@@ -369,61 +108,8 @@ describe('Unit / validator / PropTypes.object', function () {
         ctx.instance = Foo.create()
       })
 
-      itValidatesTheProperty(ctx)
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx)
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'baz')
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be an object')
-      })
+      itValidatesTheProperty(ctx, false)
+      itValidatesOnUpdate(ctx, 'object', 'Expected property bar to be an object')
     })
   })
 })

--- a/tests/unit/prop-types/one-of-test.js
+++ b/tests/unit/prop-types/one-of-test.js
@@ -52,7 +52,7 @@ describe('Unit / validator / PropTypes.oneOf', function () {
         ctx.instance = Foo.create({bar: 'alpha'})
       })
 
-      itValidatesTheProperty(ctx)
+      itValidatesTheProperty(ctx, false)
     })
 
     describe('when initialized with another valid value', function () {
@@ -60,7 +60,7 @@ describe('Unit / validator / PropTypes.oneOf', function () {
         ctx.instance = Foo.create({bar: 'bravo'})
       })
 
-      itValidatesTheProperty(ctx)
+      itValidatesTheProperty(ctx, false)
     })
 
     describe('when initialized with invalid value', function () {
@@ -68,7 +68,7 @@ describe('Unit / validator / PropTypes.oneOf', function () {
         ctx.instance = Foo.create({bar: 'charlie'})
       })
 
-      itValidatesTheProperty(ctx, 'Property bar is not one of: alpha, bravo')
+      itValidatesTheProperty(ctx, false, 'Property bar is not one of: alpha, bravo')
     })
 
     describe('when initialized without value', function () {
@@ -76,7 +76,7 @@ describe('Unit / validator / PropTypes.oneOf', function () {
         ctx.instance = Foo.create()
       })
 
-      itValidatesTheProperty(ctx, 'Missing required property bar')
+      itValidatesTheProperty(ctx, false, 'Missing required property bar')
     })
   })
 
@@ -98,7 +98,7 @@ describe('Unit / validator / PropTypes.oneOf', function () {
         ctx.instance = Foo.create({bar: 'alpha'})
       })
 
-      itValidatesTheProperty(ctx)
+      itValidatesTheProperty(ctx, false)
     })
 
     describe('when initialized with another valid value', function () {
@@ -106,7 +106,7 @@ describe('Unit / validator / PropTypes.oneOf', function () {
         ctx.instance = Foo.create({bar: 'bravo'})
       })
 
-      itValidatesTheProperty(ctx)
+      itValidatesTheProperty(ctx, false)
     })
 
     describe('when initialized with invalid value', function () {
@@ -114,7 +114,7 @@ describe('Unit / validator / PropTypes.oneOf', function () {
         ctx.instance = Foo.create({bar: 'charlie'})
       })
 
-      itValidatesTheProperty(ctx, 'Property bar is not one of: alpha, bravo')
+      itValidatesTheProperty(ctx, false, 'Property bar is not one of: alpha, bravo')
     })
 
     describe('when initialized without value', function () {
@@ -122,7 +122,7 @@ describe('Unit / validator / PropTypes.oneOf', function () {
         ctx.instance = Foo.create()
       })
 
-      itValidatesTheProperty(ctx)
+      itValidatesTheProperty(ctx, false)
     })
   })
 })

--- a/tests/unit/prop-types/one-of-type-test.js
+++ b/tests/unit/prop-types/one-of-type-test.js
@@ -70,7 +70,7 @@ describe('Unit / validator / PropTypes.oneOfType', function () {
         ctx.instance = Foo.create({bar: 1})
       })
 
-      itValidatesTheProperty(ctx)
+      itValidatesTheProperty(ctx, false)
     })
 
     describe('when initialized with string instance', function () {
@@ -78,7 +78,7 @@ describe('Unit / validator / PropTypes.oneOfType', function () {
         ctx.instance = Foo.create({bar: 'test'})
       })
 
-      itValidatesTheProperty(ctx)
+      itValidatesTheProperty(ctx, false)
     })
 
     describe('when initialized with boolean instance', function () {
@@ -86,7 +86,7 @@ describe('Unit / validator / PropTypes.oneOfType', function () {
         ctx.instance = Foo.create({bar: true})
       })
 
-      itValidatesTheProperty(ctx, 'Property bar does not match expected types: number, string')
+      itValidatesTheProperty(ctx, false, 'Property bar does not match expected types: number, string')
     })
 
     describe('when initialized without value', function () {
@@ -94,7 +94,7 @@ describe('Unit / validator / PropTypes.oneOfType', function () {
         ctx.instance = Foo.create()
       })
 
-      itValidatesTheProperty(ctx, 'Missing required property bar')
+      itValidatesTheProperty(ctx, false, 'Missing required property bar')
     })
   })
 
@@ -118,7 +118,7 @@ describe('Unit / validator / PropTypes.oneOfType', function () {
         ctx.instance = Foo.create({bar: 1})
       })
 
-      itValidatesTheProperty(ctx)
+      itValidatesTheProperty(ctx, false)
     })
 
     describe('when initialized with string instance', function () {
@@ -126,7 +126,7 @@ describe('Unit / validator / PropTypes.oneOfType', function () {
         ctx.instance = Foo.create({bar: 'test'})
       })
 
-      itValidatesTheProperty(ctx)
+      itValidatesTheProperty(ctx, false)
     })
 
     describe('when initialized with boolean instance', function () {
@@ -134,7 +134,7 @@ describe('Unit / validator / PropTypes.oneOfType', function () {
         ctx.instance = Foo.create({bar: true})
       })
 
-      itValidatesTheProperty(ctx, 'Property bar does not match expected types: number, string')
+      itValidatesTheProperty(ctx, false, 'Property bar does not match expected types: number, string')
     })
 
     describe('when initialized without value', function () {
@@ -142,7 +142,7 @@ describe('Unit / validator / PropTypes.oneOfType', function () {
         ctx.instance = Foo.create()
       })
 
-      itValidatesTheProperty(ctx)
+      itValidatesTheProperty(ctx, false)
     })
   })
 })

--- a/tests/unit/prop-types/shape-test.js
+++ b/tests/unit/prop-types/shape-test.js
@@ -52,7 +52,7 @@ describe('Unit / validator / PropTypes.shape', function () {
         })
       })
 
-      itValidatesTheProperty(ctx)
+      itValidatesTheProperty(ctx, false)
     })
 
     describe('when initialized with shape missing sub-property', function () {
@@ -64,6 +64,7 @@ describe('Unit / validator / PropTypes.shape', function () {
 
       itValidatesTheProperty(
         ctx,
+        false,
         'Property bar is missing required property baz',
         'Property bar does not match the given shape'
       )
@@ -80,6 +81,7 @@ describe('Unit / validator / PropTypes.shape', function () {
 
       itValidatesTheProperty(
         ctx,
+        false,
         'Expected property bar.baz to be a string',
         'Property bar does not match the given shape'
       )
@@ -97,6 +99,7 @@ describe('Unit / validator / PropTypes.shape', function () {
 
       itValidatesTheProperty(
         ctx,
+        false,
         'Property bar has an unknown key: spam',
         'Property bar does not match the given shape'
       )
@@ -107,7 +110,7 @@ describe('Unit / validator / PropTypes.shape', function () {
         ctx.instance = Foo.create({bar: 1})
       })
 
-      itValidatesTheProperty(ctx, 'Property bar does not match the given shape')
+      itValidatesTheProperty(ctx, false, 'Property bar does not match the given shape')
     })
 
     describe('when initialized without value', function () {
@@ -115,7 +118,7 @@ describe('Unit / validator / PropTypes.shape', function () {
         ctx.instance = Foo.create()
       })
 
-      itValidatesTheProperty(ctx, 'Missing required property bar')
+      itValidatesTheProperty(ctx, false, 'Missing required property bar')
     })
   })
 
@@ -154,7 +157,7 @@ describe('Unit / validator / PropTypes.shape', function () {
         })
       })
 
-      itValidatesTheProperty(ctx)
+      itValidatesTheProperty(ctx, false)
     })
 
     describe('when initialized with shape missing sub-property', function () {
@@ -164,7 +167,7 @@ describe('Unit / validator / PropTypes.shape', function () {
         })
       })
 
-      itValidatesTheProperty(ctx)
+      itValidatesTheProperty(ctx, false)
     })
 
     describe('when initialized with incorrect shape value', function () {
@@ -178,6 +181,7 @@ describe('Unit / validator / PropTypes.shape', function () {
 
       itValidatesTheProperty(
         ctx,
+        false,
         'Expected property bar.baz to be a string',
         'Property bar does not match the given shape'
       )
@@ -194,6 +198,7 @@ describe('Unit / validator / PropTypes.shape', function () {
 
       itValidatesTheProperty(
         ctx,
+        false,
         'Property bar has an unknown key: spam',
         'Property bar does not match the given shape'
       )
@@ -204,7 +209,7 @@ describe('Unit / validator / PropTypes.shape', function () {
         ctx.instance = Foo.create({bar: 1})
       })
 
-      itValidatesTheProperty(ctx, 'Property bar does not match the given shape')
+      itValidatesTheProperty(ctx, false, 'Property bar does not match the given shape')
     })
 
     describe('when initialized without value', function () {
@@ -212,7 +217,7 @@ describe('Unit / validator / PropTypes.shape', function () {
         ctx.instance = Foo.create()
       })
 
-      itValidatesTheProperty(ctx, 'Missing required property bar')
+      itValidatesTheProperty(ctx, false, 'Missing required property bar')
     })
   })
 
@@ -257,7 +262,7 @@ describe('Unit / validator / PropTypes.shape', function () {
         })
       })
 
-      itValidatesTheProperty(ctx)
+      itValidatesTheProperty(ctx, false)
     })
 
     describe('when initialized with shape missing sub-property', function () {
@@ -269,6 +274,7 @@ describe('Unit / validator / PropTypes.shape', function () {
 
       itValidatesTheProperty(
         ctx,
+        false,
         'Property bar is missing required property baz',
         'Property bar does not match the given shape'
       )
@@ -285,6 +291,7 @@ describe('Unit / validator / PropTypes.shape', function () {
 
       itValidatesTheProperty(
         ctx,
+        false,
         'Expected property bar.baz to be a string',
         'Property bar does not match the given shape'
       )
@@ -302,6 +309,7 @@ describe('Unit / validator / PropTypes.shape', function () {
 
       itValidatesTheProperty(
         ctx,
+        false,
         'Property bar has an unknown key: spam',
         'Property bar does not match the given shape'
       )
@@ -312,7 +320,7 @@ describe('Unit / validator / PropTypes.shape', function () {
         ctx.instance = Foo.create({bar: 1})
       })
 
-      itValidatesTheProperty(ctx, 'Property bar does not match the given shape')
+      itValidatesTheProperty(ctx, false, 'Property bar does not match the given shape')
     })
 
     describe('when initialized without value', function () {
@@ -320,7 +328,7 @@ describe('Unit / validator / PropTypes.shape', function () {
         ctx.instance = Foo.create()
       })
 
-      itValidatesTheProperty(ctx)
+      itValidatesTheProperty(ctx, false)
     })
   })
 
@@ -373,7 +381,7 @@ describe('Unit / validator / PropTypes.shape', function () {
         })
       })
 
-      itValidatesTheProperty(ctx)
+      itValidatesTheProperty(ctx, false)
     })
 
     describe('when initialized with shape missing sub-property', function () {
@@ -383,7 +391,7 @@ describe('Unit / validator / PropTypes.shape', function () {
         })
       })
 
-      itValidatesTheProperty(ctx)
+      itValidatesTheProperty(ctx, false)
     })
 
     describe('when initialized with incorrect shape value', function () {
@@ -397,6 +405,7 @@ describe('Unit / validator / PropTypes.shape', function () {
 
       itValidatesTheProperty(
         ctx,
+        false,
         'Expected property bar.baz to be a string',
         'Property bar does not match the given shape'
       )
@@ -414,6 +423,7 @@ describe('Unit / validator / PropTypes.shape', function () {
 
       itValidatesTheProperty(
         ctx,
+        false,
         'Property bar has an unknown key: spam',
         'Property bar does not match the given shape'
       )
@@ -424,7 +434,7 @@ describe('Unit / validator / PropTypes.shape', function () {
         ctx.instance = Foo.create({bar: 1})
       })
 
-      itValidatesTheProperty(ctx, 'Property bar does not match the given shape')
+      itValidatesTheProperty(ctx, false, 'Property bar does not match the given shape')
     })
 
     describe('when initialized without value', function () {
@@ -432,7 +442,7 @@ describe('Unit / validator / PropTypes.shape', function () {
         ctx.instance = Foo.create()
       })
 
-      itValidatesTheProperty(ctx)
+      itValidatesTheProperty(ctx, false)
     })
   })
 })

--- a/tests/unit/prop-types/string-test.js
+++ b/tests/unit/prop-types/string-test.js
@@ -2,11 +2,15 @@
  * Unit test for the PropTypes.string validator
  */
 import Ember from 'ember'
-const {Logger} = Ember
 import {afterEach, beforeEach, describe} from 'mocha'
 import sinon from 'sinon'
 
-import {itValidatesTheProperty, spyOnValidateMethods} from 'dummy/tests/helpers/validator'
+import {
+  itValidatesOnUpdate,
+  itValidatesTheProperty,
+  spyOnValidateMethods
+} from 'dummy/tests/helpers/validator'
+
 import PropTypesMixin, {PropTypes} from 'ember-prop-types/mixins/prop-types'
 
 const requiredDef = {
@@ -48,61 +52,8 @@ describe('Unit / validator / PropTypes.string', function () {
         ctx.instance = Foo.create({bar: 'baz'})
       })
 
-      itValidatesTheProperty(ctx)
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'baz')
-        })
-
-        itValidatesTheProperty(ctx)
-      })
+      itValidatesTheProperty(ctx, false)
+      itValidatesOnUpdate(ctx, 'string', 'Expected property bar to be a string')
     })
 
     describe('when initialized with number value', function () {
@@ -110,61 +61,8 @@ describe('Unit / validator / PropTypes.string', function () {
         ctx.instance = Foo.create({bar: 1})
       })
 
-      itValidatesTheProperty(ctx, 'Expected property bar to be a string')
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'baz')
-        })
-
-        itValidatesTheProperty(ctx)
-      })
+      itValidatesTheProperty(ctx, false, 'Expected property bar to be a string')
+      itValidatesOnUpdate(ctx, 'string', 'Expected property bar to be a string')
     })
 
     describe('when initialized without value', function () {
@@ -172,61 +70,8 @@ describe('Unit / validator / PropTypes.string', function () {
         ctx.instance = Foo.create()
       })
 
-      itValidatesTheProperty(ctx, 'Missing required property bar')
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'baz')
-        })
-
-        itValidatesTheProperty(ctx)
-      })
+      itValidatesTheProperty(ctx, false, 'Missing required property bar')
+      itValidatesOnUpdate(ctx, 'string', 'Expected property bar to be a string')
     })
   })
 
@@ -245,61 +90,8 @@ describe('Unit / validator / PropTypes.string', function () {
         ctx.instance = Foo.create({bar: 'baz'})
       })
 
-      itValidatesTheProperty(ctx)
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'baz')
-        })
-
-        itValidatesTheProperty(ctx)
-      })
+      itValidatesTheProperty(ctx, false)
+      itValidatesOnUpdate(ctx, 'string', 'Expected property bar to be a string')
     })
 
     describe('when initialized with number value', function () {
@@ -307,61 +99,8 @@ describe('Unit / validator / PropTypes.string', function () {
         ctx.instance = Foo.create({bar: 1})
       })
 
-      itValidatesTheProperty(ctx, 'Expected property bar to be a string')
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'baz')
-        })
-
-        itValidatesTheProperty(ctx)
-      })
+      itValidatesTheProperty(ctx, false, 'Expected property bar to be a string')
+      itValidatesOnUpdate(ctx, 'string', 'Expected property bar to be a string')
     })
 
     describe('when initialized without value', function () {
@@ -369,61 +108,8 @@ describe('Unit / validator / PropTypes.string', function () {
         ctx.instance = Foo.create()
       })
 
-      itValidatesTheProperty(ctx)
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a string')
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'baz')
-        })
-
-        itValidatesTheProperty(ctx)
-      })
+      itValidatesTheProperty(ctx, false)
+      itValidatesOnUpdate(ctx, 'string', 'Expected property bar to be a string')
     })
   })
 })

--- a/tests/unit/prop-types/symbol-test.js
+++ b/tests/unit/prop-types/symbol-test.js
@@ -2,11 +2,15 @@
  * Unit test for the PropTypes.symbol validator
  */
 import Ember from 'ember'
-const {Logger} = Ember
 import {afterEach, beforeEach, describe} from 'mocha'
 import sinon from 'sinon'
 
-import {itValidatesTheProperty, spyOnValidateMethods} from 'dummy/tests/helpers/validator'
+import {
+  itValidatesOnUpdate,
+  itValidatesTheProperty,
+  spyOnValidateMethods
+} from 'dummy/tests/helpers/validator'
+
 import PropTypesMixin, {PropTypes} from 'ember-prop-types/mixins/prop-types'
 
 const requiredDef = {
@@ -48,70 +52,8 @@ describe('Unit / validator / PropTypes.symbol', function () {
         ctx.instance = Foo.create({bar: Symbol()})
       })
 
-      itValidatesTheProperty(ctx)
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'spam')
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
-      })
-
-      describe('when updated with symbol value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', Symbol())
-        })
-
-        itValidatesTheProperty(ctx)
-      })
+      itValidatesTheProperty(ctx, false)
+      itValidatesOnUpdate(ctx, 'symbol', 'Expected property bar to be a symbol')
     })
 
     describe('when initialized with string value', function () {
@@ -119,70 +61,8 @@ describe('Unit / validator / PropTypes.symbol', function () {
         ctx.instance = Foo.create({bar: 'baz'})
       })
 
-      itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'spam')
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
-      })
-
-      describe('when updated with symbol value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', Symbol())
-        })
-
-        itValidatesTheProperty(ctx)
-      })
+      itValidatesTheProperty(ctx, false, 'Expected property bar to be a symbol')
+      itValidatesOnUpdate(ctx, 'symbol', 'Expected property bar to be a symbol')
     })
 
     describe('when initialized without value', function () {
@@ -190,70 +70,8 @@ describe('Unit / validator / PropTypes.symbol', function () {
         ctx.instance = Foo.create()
       })
 
-      itValidatesTheProperty(ctx, 'Missing required property bar')
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'spam')
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
-      })
-
-      describe('when updated with symbol value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', Symbol())
-        })
-
-        itValidatesTheProperty(ctx)
-      })
+      itValidatesTheProperty(ctx, false, 'Missing required property bar')
+      itValidatesOnUpdate(ctx, 'symbol', 'Expected property bar to be a symbol')
     })
   })
 
@@ -272,70 +90,8 @@ describe('Unit / validator / PropTypes.symbol', function () {
         ctx.instance = Foo.create({bar: Symbol()})
       })
 
-      itValidatesTheProperty(ctx)
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'spam')
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
-      })
-
-      describe('when updated with symbol value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', Symbol())
-        })
-
-        itValidatesTheProperty(ctx)
-      })
+      itValidatesTheProperty(ctx, false)
+      itValidatesOnUpdate(ctx, 'symbol', 'Expected property bar to be a symbol')
     })
 
     describe('when initialized with string value', function () {
@@ -343,70 +99,8 @@ describe('Unit / validator / PropTypes.symbol', function () {
         ctx.instance = Foo.create({bar: 'baz'})
       })
 
-      itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'spam')
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
-      })
-
-      describe('when updated with symbol value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', Symbol())
-        })
-
-        itValidatesTheProperty(ctx)
-      })
+      itValidatesTheProperty(ctx, false, 'Expected property bar to be a symbol')
+      itValidatesOnUpdate(ctx, 'symbol', 'Expected property bar to be a symbol')
     })
 
     describe('when initialized without value', function () {
@@ -414,70 +108,8 @@ describe('Unit / validator / PropTypes.symbol', function () {
         ctx.instance = Foo.create()
       })
 
-      itValidatesTheProperty(ctx)
-
-      describe('when updated with array value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', [])
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
-      })
-
-      describe('when updated with boolean value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', false)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
-      })
-
-      describe('when updated with null value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', null)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
-      })
-
-      describe('when updated with number value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 2)
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
-      })
-
-      describe('when updated with object value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', {})
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
-      })
-
-      describe('when updated with string value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', 'spam')
-        })
-
-        itValidatesTheProperty(ctx, 'Expected property bar to be a symbol')
-      })
-
-      describe('when updated with symbol value', function () {
-        beforeEach(function () {
-          Logger.warn.reset()
-          ctx.instance.set('bar', Symbol())
-        })
-
-        itValidatesTheProperty(ctx)
-      })
+      itValidatesTheProperty(ctx, false)
+      itValidatesOnUpdate(ctx, 'symbol', 'Expected property bar to be a symbol')
     })
   })
 })


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

Resolves #81
Resolves #91
Resolves #92

# CHANGELOG

* **Added** the ability to configure validation errors to be throw as errors instead of logged as warnings. To enable this feature simply add the following to `config/environment.js`:

  ```js
  'ember-prop-types': {
    throwErrors: true
  }
  ```
