### PR TITLE
Support spread property on initial validation

### DIFF
--- a/addon/mixins/prop-types.js
+++ b/addon/mixins/prop-types.js
@@ -2,12 +2,13 @@
  * The PropTypesMixin definition
  */
 import Ember from 'ember'
-const {Mixin, getWithDefault, typeOf} = Ember
+const {Mixin, get, getWithDefault, typeOf} = Ember
 import config from 'ember-get-config'
 
 import PropTypes, {logger, validators} from '../utils/prop-types'
 
 export const settings = {
+  spreadProperty: get(config, 'ember-prop-types.spreadProperty'),
   throwErrors: getWithDefault(config, 'ember-prop-types.throwErrors', false),
   validateOnUpdate: getWithDefault(config, 'ember-prop-types.validateOnUpdate', false)
 }
@@ -19,7 +20,11 @@ export const helpers = {
 
   /* eslint-disable complexity */
   validateProperty (ctx, name, def) {
-    const value = ctx.get(name)
+    let value = get(ctx, name)
+
+    if (value === undefined && settings.spreadProperty) {
+      value = get(ctx, `${settings.spreadProperty}.${name}`)
+    }
 
     if (value === undefined) {
       if (!def.required) {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "ember-prism": "0.0.8",
     "ember-resolver": "^2.0.3",
     "ember-sinon": "^0.6.0",
+    "ember-spread": "^1.0.0",
     "eslint": "^3.4.0",
     "eslint-config-frost-standard": "^5.3.2",
     "loader.js": "^4.0.0"

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -31,6 +31,12 @@ const errorConfig = `
 }
 `
 
+const spreadConfig = `
+'ember-prop-types': {
+  spreadProperty: 'options'
+}
+`
+
 const updateConfig = `
 'ember-prop-types': {
   validateOnUpdate: true
@@ -43,6 +49,7 @@ export default Route.extend({
       contributors,
       defaultsExample,
       errorConfig,
+      spreadConfig,
       updateConfig,
       validators
     }

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -30,6 +30,14 @@
   {{#code-block language="javascript"}}{{model.updateConfig}}{{/code-block}}
 </p>
 
+<p>
+  Some projects desire to use <em>ember-prop-types</em> in conjunction with <em>ember-spread</em> which don't
+  play well as <em>ember-prop-types</em> doesn't apply validation on the <em>options</em> property used by
+  <em>ember-spread</em>. You can however inform <em>ember-prop-types</em> to look for properties under this
+  option with the following configuration:
+  {{#code-block language="javascript"}}{{model.spreadConfig}}{{/code-block}}
+</p>
+
 <h2>Validators</h2>
 
 <div class="flex">

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -13,6 +13,7 @@ module.exports = function (environment) {
     modulePrefix: 'dummy',
 
     'ember-prop-types': {
+      spreadProperty: 'options',
       throwErrors: false,
       validateOnUpdate: true
     }

--- a/tests/unit/prop-types/bool-test.js
+++ b/tests/unit/prop-types/bool-test.js
@@ -2,6 +2,7 @@
  * Unit test for the PropTypes.bool validator
  */
 import Ember from 'ember'
+import SpreadMixin from 'ember-spread'
 import {afterEach, beforeEach, describe} from 'mocha'
 import sinon from 'sinon'
 
@@ -40,7 +41,7 @@ describe('Unit / validator / PropTypes.bool', function () {
   describe('when required', function () {
     beforeEach(function () {
       ctx.def = requiredDef
-      Foo = Ember.Object.extend(PropTypesMixin, {
+      Foo = Ember.Object.extend(SpreadMixin, PropTypesMixin, {
         propTypes: {
           bar: PropTypes.bool.isRequired
         }
@@ -73,12 +74,46 @@ describe('Unit / validator / PropTypes.bool', function () {
       itValidatesTheProperty(ctx, false, 'Missing required property bar')
       itValidatesOnUpdate(ctx, 'bool', 'Expected property bar to be a boolean')
     })
+
+    describe('when initialized with boolean value via spread property', function () {
+      beforeEach(function () {
+        ctx.instance = Foo.create({
+          options: {
+            bar: true
+          }
+        })
+      })
+
+      itValidatesTheProperty(ctx, false)
+    })
+
+    describe('when initialized with number value via spread property', function () {
+      beforeEach(function () {
+        ctx.instance = Foo.create({
+          options: {
+            bar: 1
+          }
+        })
+      })
+
+      itValidatesTheProperty(ctx, false, 'Expected property bar to be a boolean')
+    })
+
+    describe('when initialized without value via spread property', function () {
+      beforeEach(function () {
+        ctx.instance = Foo.create({
+          options: {}
+        })
+      })
+
+      itValidatesTheProperty(ctx, false, 'Missing required property bar')
+    })
   })
 
   describe('when not required', function () {
     beforeEach(function () {
       ctx.def = notRequiredDef
-      Foo = Ember.Object.extend(PropTypesMixin, {
+      Foo = Ember.Object.extend(SpreadMixin, PropTypesMixin, {
         propTypes: {
           bar: PropTypes.bool
         }
@@ -110,6 +145,40 @@ describe('Unit / validator / PropTypes.bool', function () {
 
       itValidatesTheProperty(ctx, false)
       itValidatesOnUpdate(ctx, 'bool', 'Expected property bar to be a boolean')
+    })
+
+    describe('when initialized with boolean value via spread property', function () {
+      beforeEach(function () {
+        ctx.instance = Foo.create({
+          options: {
+            bar: true
+          }
+        })
+      })
+
+      itValidatesTheProperty(ctx, false)
+    })
+
+    describe('when initialized with number value via spread property', function () {
+      beforeEach(function () {
+        ctx.instance = Foo.create({
+          options: {
+            bar: 1
+          }
+        })
+      })
+
+      itValidatesTheProperty(ctx, false, 'Expected property bar to be a boolean')
+    })
+
+    describe('when initialized without value via spread property', function () {
+      beforeEach(function () {
+        ctx.instance = Foo.create({
+          options: {}
+        })
+      })
+
+      itValidatesTheProperty(ctx, false)
     })
   })
 })


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Added** ability to validate properties on initialized that are nested under a single property via something like [ember-spread](https://github.com/ciena-blueplanet/ember-spread).
