### PR TITLE
Allow validation to be disabled/enabled via setting

### DIFF
--- a/addon/mixins/prop-types.js
+++ b/addon/mixins/prop-types.js
@@ -10,6 +10,7 @@ import PropTypes, {logger, validators} from '../utils/prop-types'
 export const settings = {
   spreadProperty: get(config, 'ember-prop-types.spreadProperty'),
   throwErrors: getWithDefault(config, 'ember-prop-types.throwErrors', false),
+  validate: get(config, 'ember-prop-types.validate'),
   validateOnUpdate: getWithDefault(config, 'ember-prop-types.validateOnUpdate', false)
 }
 
@@ -45,7 +46,14 @@ export const helpers = {
   /* eslint-enable complexity */
 
   validatePropTypes (ctx) {
-    if (!config || config.environment === 'production') {
+    const disabledForEnv = settings.validate === false
+    const isProduction = !config || config.environment === 'production'
+    const settingMissing = settings.validate === undefined
+
+    if (
+      disabledForEnv ||
+      (settingMissing && isProduction)
+    ) {
       return
     }
 

--- a/addon/utils/logger.js
+++ b/addon/utils/logger.js
@@ -16,11 +16,13 @@ export default {
    * @param {Boolean} throwError - whether or not to throw error
    */
   warn (obj, message, throwError) {
+    const id = obj.toString()
+    message = `[${id}]: ${message}`
+
     if (throwError) {
       this.throwError(message)
     } else {
-      const id = obj.toString()
-      Logger.warn(`[${id}]: ${message}`)
+      Logger.warn(message)
     }
   }
 }

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -43,6 +43,12 @@ const updateConfig = `
 }
 `
 
+const validateConfig = `
+'ember-prop-types': {
+  validate: true
+}
+`
+
 export default Route.extend({
   model () {
     return {
@@ -51,6 +57,7 @@ export default Route.extend({
       errorConfig,
       spreadConfig,
       updateConfig,
+      validateConfig,
       validators
     }
   }

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -38,6 +38,14 @@
   {{#code-block language="javascript"}}{{model.spreadConfig}}{{/code-block}}
 </p>
 
+<p>
+  <em>ember-prop-types</em> will validate properties in any environment other than <em>production</em> out-of-box.
+  However if you find yourself wanting to enable validations in your production environment or disable validations
+  in a specific environment such as your test environment you can configure <em>ember-prop-types</em> with the
+  following setting on an environment by environment basis:
+  {{#code-block language="javascript"}}{{model.validateConfig}}{{/code-block}}
+</p>
+
 <h2>Validators</h2>
 
 <div class="flex">

--- a/tests/helpers/validator.js
+++ b/tests/helpers/validator.js
@@ -298,7 +298,7 @@ export function itValidatesTheProperty (ctx, throwErrors, ...warningMessages) {
       it('should throw errors', function () {
         expect(logger.throwError).to.have.callCount(warningMessages.length)
         warningMessages.forEach((msg) => {
-          expect(logger.throwError).to.have.been.calledWith(msg)
+          expect(logger.throwError).to.have.been.calledWith(`[${instance.toString()}]: ${msg}`)
         })
       })
     } else {

--- a/tests/unit/mixins/prop-types-test.js
+++ b/tests/unit/mixins/prop-types-test.js
@@ -7,7 +7,7 @@ const {Component, Logger, Mixin} = Ember
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
 
-import PropTypesMixin, {PropTypes, helpers} from 'ember-prop-types/mixins/prop-types'
+import PropTypesMixin, {PropTypes, helpers, settings} from 'ember-prop-types/mixins/prop-types'
 
 describe('Unit / Mixins / prop-types', function () {
   let sandbox
@@ -73,44 +73,162 @@ describe('Unit / Mixins / prop-types', function () {
   })
 
   describe('propTypes defined but unknown type on Ember.Object', function () {
+    let MyObject
+
     beforeEach(function () {
       sandbox.spy(Logger, 'warn')
       sandbox.spy(helpers, 'validateProperty')
-      const MyObject = Ember.Object.extend(PropTypesMixin, {
+      MyObject = Ember.Object.extend(PropTypesMixin, {
         propTypes: {
           foo: PropTypes.doesNotExist
         }
       })
-      MyObject.create()
     })
 
-    it('does not call validateProperty', function () {
-      expect(helpers.validateProperty).to.have.callCount(0)
+    describe('validate setting not defined', function () {
+      let validateSettingOriginalValue
+
+      beforeEach(function () {
+        validateSettingOriginalValue = settings.validate
+        settings.validate = undefined
+        MyObject.create()
+      })
+
+      afterEach(function () {
+        settings.validate = validateSettingOriginalValue
+      })
+
+      it('does not call validateProperty', function () {
+        expect(helpers.validateProperty).to.have.callCount(0)
+      })
+
+      it('logs warning message', function () {
+        expect(Logger.warn).to.have.callCount(1)
+      })
     })
 
-    it('logs warning message', function () {
-      expect(Logger.warn).to.have.callCount(1)
+    describe('validate setting set to false', function () {
+      let validateSettingOriginalValue
+
+      beforeEach(function () {
+        validateSettingOriginalValue = settings.validate
+        settings.validate = false
+        MyObject.create()
+      })
+
+      afterEach(function () {
+        settings.validate = validateSettingOriginalValue
+      })
+
+      it('does not call validateProperty', function () {
+        expect(helpers.validateProperty).to.have.callCount(0)
+      })
+
+      it('does not log warning message', function () {
+        expect(Logger.warn).to.have.callCount(0)
+      })
+    })
+
+    describe('validate setting set to true', function () {
+      let validateSettingOriginalValue
+
+      beforeEach(function () {
+        validateSettingOriginalValue = settings.validate
+        settings.validate = true
+        MyObject.create()
+      })
+
+      afterEach(function () {
+        settings.validate = validateSettingOriginalValue
+      })
+
+      it('does not call validateProperty', function () {
+        expect(helpers.validateProperty).to.have.callCount(0)
+      })
+
+      it('logs warning message', function () {
+        expect(Logger.warn).to.have.callCount(1)
+      })
     })
   })
 
   describe('propTypes defined but unknown type on Ember.Component', function () {
+    let MyComponent
+
     beforeEach(function () {
       sandbox.spy(Logger, 'warn')
       sandbox.spy(helpers, 'validateProperty')
-      const MyComponent = Component.extend(PropTypesMixin, {
+      MyComponent = Component.extend(PropTypesMixin, {
         propTypes: {
           foo: PropTypes.doesNotExist
         }
       })
-      MyComponent.create()
     })
 
-    it('does not call validateProperty', function () {
-      expect(helpers.validateProperty).to.have.callCount(0)
+    describe('validate setting not defined', function () {
+      let validateSettingOriginalValue
+
+      beforeEach(function () {
+        validateSettingOriginalValue = settings.validate
+        settings.validate = undefined
+        MyComponent.create()
+      })
+
+      afterEach(function () {
+        settings.validate = validateSettingOriginalValue
+      })
+
+      it('does not call validateProperty', function () {
+        expect(helpers.validateProperty).to.have.callCount(0)
+      })
+
+      it('logs warning message', function () {
+        expect(Logger.warn).to.have.callCount(1)
+      })
     })
 
-    it('logs warning message', function () {
-      expect(Logger.warn).to.have.callCount(1)
+    describe('validate setting set to false', function () {
+      let validateSettingOriginalValue
+
+      beforeEach(function () {
+        validateSettingOriginalValue = settings.validate
+        settings.validate = false
+        MyComponent.create()
+      })
+
+      afterEach(function () {
+        settings.validate = validateSettingOriginalValue
+      })
+
+      it('does not call validateProperty', function () {
+        expect(helpers.validateProperty).to.have.callCount(0)
+      })
+
+      it('does not log warning message', function () {
+        expect(Logger.warn).to.have.callCount(0)
+      })
+    })
+
+    describe('validate setting set to true', function () {
+      let validateSettingOriginalValue
+
+      beforeEach(function () {
+        validateSettingOriginalValue = settings.validate
+        settings.validate = true
+        MyComponent.create()
+      })
+
+      afterEach(function () {
+        settings.validate = validateSettingOriginalValue
+      })
+
+      it('does not call validateProperty', function () {
+        expect(helpers.validateProperty).to.have.callCount(0)
+      })
+
+      it('logs warning message', function () {
+        expect(Logger.warn).to.have.callCount(1)
+      })
     })
   })
 


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

Resolves #90

# CHANGELOG

* **Added** the ability to enable/disable validation from an environment configuration setting, allowing consumers to control which environments `ember-prop-types` warnings/errors appear in. Below is an example of how to explicitly enable validation:

  ```js
  'ember-prop-types': {
    validate: true
  }
  ```

  > Note: Without explicitly adding this setting things will continue to work as they did before in which validation is enabled for all environments except *production*.

* **Fixed** validation error messages when `throwErrors` is set to true to match error messages when errors are not thrown (logging warnings instead).
