### PR TITLE
Add EmberComponent type

### DIFF
--- a/addon/utils/prop-types.js
+++ b/addon/utils/prop-types.js
@@ -37,6 +37,7 @@ export function generateType (key) {
   'array',
   'bool',
   'element',
+  'EmberComponent',
   'EmberObject',
   'func',
   'null',

--- a/addon/utils/validators/ember-component.js
+++ b/addon/utils/validators/ember-component.js
@@ -1,0 +1,22 @@
+/**
+ * The PropTypes.EmberComponent validator
+ */
+
+import Ember from 'ember'
+const {typeOf} = Ember
+
+import logger from '../logger'
+
+export default function (ctx, name, value, def, logErrors, throwErrors) {
+  const isObject = typeOf(value) === 'object'
+
+  const valid = isObject && Object.keys(value).some((key) => {
+    return key.indexOf('COMPONENT_CELL') === 0
+  })
+
+  if (!valid && logErrors) {
+    logger.warn(ctx, `Expected property ${name} to be an Ember.Component`, throwErrors)
+  }
+
+  return valid
+}

--- a/addon/utils/validators/ember-component.js
+++ b/addon/utils/validators/ember-component.js
@@ -11,6 +11,7 @@ export default function (ctx, name, value, def, logErrors, throwErrors) {
   const isObject = typeOf(value) === 'object'
 
   const valid = isObject && Object.keys(value).some((key) => {
+    // NOTE: this is based on internal API and thus could break without warning.
     return key.indexOf('COMPONENT_CELL') === 0
   })
 

--- a/addon/utils/validators/index.js
+++ b/addon/utils/validators/index.js
@@ -5,6 +5,7 @@ import array from './array'
 import arrayOf from './array-of'
 import bool from './bool'
 import element from './element'
+import emberComponent from './ember-component'
 import emberObject from './ember-object'
 import func from './func'
 import instanceOf from './instance-of'
@@ -24,6 +25,7 @@ const validators = {
   array,
   bool,
   element,
+  EmberComponent: emberComponent,
   EmberObject: emberObject,
   func,
   instanceOf,

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -11,7 +11,10 @@ module.exports = function (defaults) {
       useLintTree: false
     },
     'ember-prism': {
-      components: ['javascript'],
+      components: [
+        'handlebars',
+        'javascript'
+      ],
       theme: 'okaidia'
     }
   })

--- a/tests/dummy/app/fixtures/validators.js
+++ b/tests/dummy/app/fixtures/validators.js
@@ -85,6 +85,30 @@ export default Component.extend(PropTypeMixin, {
     name: 'element'
   },
   {
+    description: 'Property must be from {{component}} helper.',
+    example: `
+import Ember from 'ember'
+const {Component} = Ember
+import PropTypeMixin, {PropTypes} from 'ember-prop-types'
+
+export default Component.extend(PropTypeMixin, {
+  propTypes: {
+    bar: PropTypes.EmberComponent,
+    baz: PropTypes.EmberComponent.isRequired,
+    foo: PropTypes.EmberComponent({required: true})
+  }
+})
+    `,
+    hbs: `
+{{my-component
+  bar={{component 'foo-bar'}}
+  baz={{component 'foo-bar' 'test' 'spam'}}
+  foo={{component prop1='test' prop2='spam'}}
+}}
+    `,
+    name: 'EmberComponent'
+  },
+  {
     description: 'Property must be an Ember.Object.',
     example: `
 import Ember from 'ember'

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -30,7 +30,12 @@
     <section>
       <dt>{{validator.name}}</dt>
       <dl>{{validator.description}}</dl>
+      <h4>Component Definition</h4>
       {{#code-block language="javascript"}}{{validator.example}}{{/code-block}}
+      {{#if validator.hbs}}
+        <h4>Consumption in Templae</h4>
+        {{#code-block language="handlebars"}}{{validator.hbs}}{{/code-block}}
+      {{/if}}
     </section>
   {{/each}}
 </div>

--- a/tests/unit/prop-types/hash-api/ember-component-test.js
+++ b/tests/unit/prop-types/hash-api/ember-component-test.js
@@ -1,0 +1,155 @@
+/**
+ * Unit test for the PropTypes.element validator
+ */
+import Ember from 'ember'
+import {afterEach, beforeEach, describe} from 'mocha'
+import sinon from 'sinon'
+
+import {itValidatesTheProperty, spyOnValidateMethods} from 'dummy/tests/helpers/validator'
+import PropTypesMixin, {PropTypes} from 'ember-prop-types/mixins/prop-types'
+
+const requiredDef = {
+  required: true,
+  type: 'EmberComponent'
+}
+
+const notRequiredDef = {
+  required: false,
+  type: 'EmberComponent'
+}
+
+/**
+ * Generate object that looks like what {{component}} helper generates
+ * @param {String} name - name of component
+ * @param {Array} [positionalParams=[]] positional parameters
+ * @param {Object} [hash={}] - named parameters
+ * @returns {Object} object similar to that of {{component}} helper
+ */
+function component (name, positionalParams = [], hash = {}) {
+  return {
+    'COMPONENT_CELL [id=__ember14840705316191443762638799]': true,
+    'COMPONENT_HASH [id=__ember14840705316191439762370039]': hash,
+    'COMPONENT_PATH [id=__ember1484070531619695987718721]': name,
+    'COMPONENT_POSITIONAL_PARAMS [id=__ember1484070531619818135796194]': positionalParams,
+    'COMPONENT_SOURCE [id=__ember1484070531619148759557471]': `dummy/pods/components/${name}/template.hbs`
+  }
+}
+
+describe('Unit / validator / PropTypes.EmberComponent', function () {
+  const ctx = {propertyName: 'bar'}
+  let sandbox, Foo
+
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create()
+    spyOnValidateMethods(sandbox)
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  describe('when required option not present', function () {
+    beforeEach(function () {
+      ctx.def = notRequiredDef
+      Foo = Ember.Object.extend(PropTypesMixin, {
+        propTypes: {
+          bar: PropTypes.EmberComponent()
+        }
+      })
+    })
+
+    describe('when initialized with {{component}} value', function () {
+      beforeEach(function () {
+        ctx.instance = Foo.create({bar: component('foo-bar')})
+      })
+
+      itValidatesTheProperty(ctx, false)
+    })
+
+    describe('when initialized with POJO value', function () {
+      beforeEach(function () {
+        ctx.instance = Foo.create({bar: {}})
+      })
+
+      itValidatesTheProperty(ctx, false, 'Expected property bar to be an Ember.Component')
+    })
+
+    describe('when initialized without value', function () {
+      beforeEach(function () {
+        ctx.instance = Foo.create()
+      })
+
+      itValidatesTheProperty(ctx, false)
+    })
+  })
+
+  describe('when required', function () {
+    beforeEach(function () {
+      ctx.def = requiredDef
+      Foo = Ember.Object.extend(PropTypesMixin, {
+        propTypes: {
+          bar: PropTypes.EmberComponent({required: true})
+        }
+      })
+    })
+
+    describe('when initialized with {{component}} value', function () {
+      beforeEach(function () {
+        ctx.instance = Foo.create({bar: component('foo-bar')})
+      })
+
+      itValidatesTheProperty(ctx, false)
+    })
+
+    describe('when initialized with POJO value', function () {
+      beforeEach(function () {
+        ctx.instance = Foo.create({bar: {}})
+      })
+
+      itValidatesTheProperty(ctx, false, 'Expected property bar to be an Ember.Component')
+    })
+
+    describe('when initialized without value', function () {
+      beforeEach(function () {
+        ctx.instance = Foo.create()
+      })
+
+      itValidatesTheProperty(ctx, false, 'Missing required property bar')
+    })
+  })
+
+  describe('when not required', function () {
+    beforeEach(function () {
+      ctx.def = notRequiredDef
+      Foo = Ember.Object.extend(PropTypesMixin, {
+        propTypes: {
+          bar: PropTypes.EmberComponent({required: false})
+        }
+      })
+    })
+
+    describe('when initialized with {{component}} value', function () {
+      beforeEach(function () {
+        ctx.instance = Foo.create({bar: component('foo-bar')})
+      })
+
+      itValidatesTheProperty(ctx, false)
+    })
+
+    describe('when initialized with POJO value', function () {
+      beforeEach(function () {
+        ctx.instance = Foo.create({bar: {}})
+      })
+
+      itValidatesTheProperty(ctx, false, 'Expected property bar to be an Ember.Component')
+    })
+
+    describe('when initialized without value', function () {
+      beforeEach(function () {
+        ctx.instance = Foo.create()
+      })
+
+      itValidatesTheProperty(ctx, false)
+    })
+  })
+})

--- a/tests/unit/prop-types/property-api/ember-component-test.js
+++ b/tests/unit/prop-types/property-api/ember-component-test.js
@@ -1,5 +1,5 @@
 /**
- * Unit test for the PropTypes.EmberObject validator
+ * Unit test for the PropTypes.EmberComponent validator
  */
 import Ember from 'ember'
 import {afterEach, beforeEach, describe} from 'mocha'
@@ -10,16 +10,33 @@ import PropTypesMixin, {PropTypes} from 'ember-prop-types/mixins/prop-types'
 
 const requiredDef = {
   required: true,
-  type: 'EmberObject'
+  type: 'EmberComponent'
 }
 
 const notRequiredDef = {
   isRequired: requiredDef,
   required: false,
-  type: 'EmberObject'
+  type: 'EmberComponent'
 }
 
-describe('Unit / validator / PropTypes.EmberObject', function () {
+/**
+ * Generate object that looks like what {{component}} helper generates
+ * @param {String} name - name of component
+ * @param {Array} [positionalParams=[]] positional parameters
+ * @param {Object} [hash={}] - named parameters
+ * @returns {Object} object similar to that of {{component}} helper
+ */
+function component (name, positionalParams = [], hash = {}) {
+  return {
+    'COMPONENT_CELL [id=__ember14840705316191443762638799]': true,
+    'COMPONENT_HASH [id=__ember14840705316191439762370039]': hash,
+    'COMPONENT_PATH [id=__ember1484070531619695987718721]': name,
+    'COMPONENT_POSITIONAL_PARAMS [id=__ember1484070531619818135796194]': positionalParams,
+    'COMPONENT_SOURCE [id=__ember1484070531619148759557471]': `dummy/pods/components/${name}/template.hbs`
+  }
+}
+
+describe('Unit / validator / PropTypes.EmberComponent', function () {
   const ctx = {propertyName: 'bar'}
   let sandbox, Foo
 
@@ -37,14 +54,14 @@ describe('Unit / validator / PropTypes.EmberObject', function () {
       ctx.def = requiredDef
       Foo = Ember.Object.extend(PropTypesMixin, {
         propTypes: {
-          bar: PropTypes.EmberObject.isRequired
+          bar: PropTypes.EmberComponent.isRequired
         }
       })
     })
 
-    describe('when initialized with Ember.Object value', function () {
+    describe('when initialized with {{component}} value', function () {
       beforeEach(function () {
-        ctx.instance = Foo.create({bar: Ember.Object.create({})})
+        ctx.instance = Foo.create({bar: component('foo-bar')})
       })
 
       itValidatesTheProperty(ctx, false)
@@ -55,7 +72,7 @@ describe('Unit / validator / PropTypes.EmberObject', function () {
         ctx.instance = Foo.create({bar: {}})
       })
 
-      itValidatesTheProperty(ctx, false, 'Expected property bar to be an Ember.Object')
+      itValidatesTheProperty(ctx, false, 'Expected property bar to be an Ember.Component')
     })
 
     describe('when initialized without value', function () {
@@ -72,14 +89,14 @@ describe('Unit / validator / PropTypes.EmberObject', function () {
       ctx.def = notRequiredDef
       Foo = Ember.Object.extend(PropTypesMixin, {
         propTypes: {
-          bar: PropTypes.EmberObject
+          bar: PropTypes.EmberComponent
         }
       })
     })
 
-    describe('when initialized with Ember.Object value', function () {
+    describe('when initialized with {{component}} value', function () {
       beforeEach(function () {
-        ctx.instance = Foo.create({bar: Ember.Object.create({})})
+        ctx.instance = Foo.create({bar: component('foo-bar')})
       })
 
       itValidatesTheProperty(ctx, false)
@@ -90,7 +107,7 @@ describe('Unit / validator / PropTypes.EmberObject', function () {
         ctx.instance = Foo.create({bar: {}})
       })
 
-      itValidatesTheProperty(ctx, false, 'Expected property bar to be an Ember.Object')
+      itValidatesTheProperty(ctx, false, 'Expected property bar to be an Ember.Component')
     })
 
     describe('when initialized without value', function () {


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

Resolves #100 

# CHANGELOG

* **Added** `EmberComponent` prop-type for properties that come from the `{{component}}` helper.
