### PR TITLE
Add updatable option

### DIFF
--- a/addon/mixins/prop-types.js
+++ b/addon/mixins/prop-types.js
@@ -73,6 +73,11 @@ export const helpers = {
 
         if (settings.validateOnUpdate) {
           ctx.addObserver(name, ctx, function () {
+            if (def.updatable === false) {
+              helpers.handleError(ctx, `${name} should not be updated`)
+              return
+            }
+
             helpers.validateProperty(this, name, def)
           })
         }

--- a/addon/utils/prop-types.js
+++ b/addon/utils/prop-types.js
@@ -61,6 +61,10 @@ export function generateType (key) {
         def.required = options.required
       }
 
+      if (options.updatable === false) {
+        def.updatable = false
+      }
+
       return def
     }
 
@@ -91,6 +95,10 @@ PropTypes.arrayOf = function (typeDef, options) {
     type.required = options.required
   }
 
+  if (options.updatable === false) {
+    type.updatable = false
+  }
+
   return type
 }
 
@@ -116,6 +124,10 @@ PropTypes.oneOfType = function (typeDefs, options) {
     type.required = options.required
   }
 
+  if (options.updatable === false) {
+    type.updatable = false
+  }
+
   return type
 }
 
@@ -135,6 +147,10 @@ PropTypes.oneOf = function (valueOptions, options) {
     type.required = options.required
   }
 
+  if (options.updatable === false) {
+    type.updatable = false
+  }
+
   return type
 }
 
@@ -152,6 +168,10 @@ PropTypes.instanceOf = function (typeDef, options) {
 
   if ('required' in options) {
     type.required = options.required
+  }
+
+  if (options.updatable === false) {
+    type.updatable = false
   }
 
   return type
@@ -178,6 +198,10 @@ PropTypes.shape = function (typeDefs, options) {
 
   if ('required' in options) {
     type.required = options.required
+  }
+
+  if (options.updatable === false) {
+    type.updatable = false
   }
 
   return type

--- a/tests/dummy/app/fixtures/validators.js
+++ b/tests/dummy/app/fixtures/validators.js
@@ -10,7 +10,8 @@ export default Component.extend(PropTypeMixin, {
   propTypes: {
     bar: PropTypes.any,
     baz: PropTypes.any.isRequired,
-    foo: PropTypes.any({required: true})
+    foo: PropTypes.any({required: true}),
+    spam: PropTypes.any({updatable: false})
   }
 })
     `,
@@ -27,7 +28,8 @@ export default Component.extend(PropTypeMixin, {
   propTypes: {
     bar: PropTypes.array,
     baz: PropTypes.array.isRequired,
-    foo: PropTypes.array({required: true})
+    foo: PropTypes.array({required: true}),
+    spam: PropTypes.array({updatable: false})
   }
 })
     `,
@@ -44,7 +46,8 @@ export default Component.extend(PropTypeMixin, {
   propTypes: {
     bar: PropTypes.arrayOf(PropTypes.string),
     baz: PropTypes.arrayOf(PropTypes.string).isRequired,
-    foo: PropTypes.arrayOf(PropTypes.string, {required: true})
+    foo: PropTypes.arrayOf(PropTypes.string, {required: true}),
+    spam: PropTypes.arrayOf(PropTypes.string, {updatable: false})
   }
 })
     `,
@@ -61,7 +64,8 @@ export default Component.extend(PropTypeMixin, {
   propTypes: {
     bar: PropTypes.bool,
     baz: PropTypes.bool.isRequired,
-    foo: PropTypes.bool({required: true})
+    foo: PropTypes.bool({required: true}),
+    spam: PropTypes.bool({updatable: false})
   }
 })
     `,
@@ -78,7 +82,8 @@ export default Component.extend(PropTypeMixin, {
   propTypes: {
     bar: PropTypes.element,
     baz: PropTypes.element.isRequired,
-    foo: PropTypes.element({required: true})
+    foo: PropTypes.element({required: true}),
+    spam: PropTypes.element({updatable: false})
   }
 })
     `,
@@ -95,7 +100,8 @@ export default Component.extend(PropTypeMixin, {
   propTypes: {
     bar: PropTypes.EmberComponent,
     baz: PropTypes.EmberComponent.isRequired,
-    foo: PropTypes.EmberComponent({required: true})
+    foo: PropTypes.EmberComponent({required: true}),
+    spam: PropTypes.EmberComponent({updatable: false})
   }
 })
     `,
@@ -119,7 +125,8 @@ export default Component.extend(PropTypeMixin, {
   propTypes: {
     bar: PropTypes.EmberObject,
     baz: PropTypes.EmberObject.isRequired,
-    foo: PropTypes.EmberObject({required: true})
+    foo: PropTypes.EmberObject({required: true}),
+    spam: PropTypes.EmberObject({updatable: false})
   }
 })
     `,
@@ -136,7 +143,8 @@ export default Component.extend(PropTypeMixin, {
   propTypes: {
     bar: PropTypes.func,
     baz: PropTypes.func.isRequired,
-    foo: PropTypes.func({required: true})
+    foo: PropTypes.func({required: true}),
+    spam: PropTypes.func({updatable: false})
   }
 })
     `,
@@ -153,7 +161,8 @@ export default Component.extend(PropTypeMixin, {
   propTypes: {
     bar: PropTypes.instanceOf(HTMLElement),
     baz: PropTypes.instanceOf(HTMLElement).isRequired
-    foo: PropTypes.instanceOf(HTMLElement, {required: true})
+    foo: PropTypes.instanceOf(HTMLElement, {required: true}),
+    spam: PropTypes.instanceOf(HTMLElement, {updatable: false})
   }
 })
     `,
@@ -171,20 +180,7 @@ export default Component.extend(PropTypeMixin, {
     bar: PropTypes.oneOfType([
       PropTypes.null,
       PropTypes.string
-    ]),
-    baz: PropTypes.oneOfType([
-      PropTypes.null,
-      PropTypes.string
-    ]).isRequired,
-    foo: PropTypes.oneOfType(
-      [
-        PropTypes.null,
-        PropTypes.string
-      ],
-      {
-        required: true
-      }
-    )
+    ])
   }
 })
     `,
@@ -201,7 +197,8 @@ export default Component.extend(PropTypeMixin, {
   propTypes: {
     bar: PropTypes.number,
     baz: PropTypes.number.isRequired,
-    foo: PropTypes.number({required: true})
+    foo: PropTypes.number({required: true}),
+    spam: PropTypes.number({updatable: false})
   }
 })
     `,
@@ -218,7 +215,8 @@ export default Component.extend(PropTypeMixin, {
   propTypes: {
     bar: PropTypes.object,
     baz: PropTypes.object.isRequired,
-    foo: PropTypes.object({required: true})
+    foo: PropTypes.object({required: true}),
+    spam: PropTypes.object({updatable: false})
   }
 })
     `,
@@ -242,6 +240,15 @@ export default Component.extend(PropTypeMixin, {
       ],
       {
         required: true
+      }
+    ),
+    spam: PropTypes.oneOf(
+      [
+        'bar',
+        'baz'
+      ],
+      {
+        updatable: false
       }
     )
   }
@@ -274,6 +281,15 @@ export default Component.extend(PropTypeMixin, {
       {
         required: true
       }
+    ),
+    spam: PropTypes.oneOfType(
+      [
+        PropTypes.null,
+        PropTypes.string
+      ],
+      {
+        updatable: false
+      }
     )
   }
 })
@@ -305,6 +321,15 @@ export default Component.extend(PropTypeMixin, {
       {
         required: true
       }
+    ),
+    spam: PropTypes.shape(
+      {
+        bar: PropTypes.number.isRequired,
+        baz: PropTypes.string
+      },
+      {
+        updatable: false
+      }
     )
   }
 })
@@ -322,7 +347,8 @@ export default Component.extend(PropTypeMixin, {
   propTypes: {
     bar: PropTypes.string,
     baz: PropTypes.string.isRequired,
-    foo: PropTypes.string({required: true})
+    foo: PropTypes.string({required: true}),
+    spam: PropTypes.string({updatable: false})
   }
 })
     `,
@@ -339,7 +365,8 @@ export default Component.extend(PropTypeMixin, {
   propTypes: {
     bar: PropTypes.symbol,
     baz: PropTypes.symbol.isRequired,
-    foo: PropTypes.symbol({required: true})
+    foo: PropTypes.symbol({required: true}),
+    spam: PropTypes.symbol({updatable: false})
   }
 })
     `,

--- a/tests/index.html
+++ b/tests/index.html
@@ -25,11 +25,8 @@
     <script src="assets/vendor.js"></script>
     <script src="assets/test-support.js"></script>
     <script src="assets/dummy.js"></script>
-    <script src="assets/blanket-options.js"></script>
-    <script src="assets/blanket-loader.js"></script>
     <script src="testem.js" integrity=""></script>
     <script src="assets/tests.js"></script>
-    <script src="assets/test-loader.js"></script>
 
     {{content-for 'body-footer'}}
     {{content-for 'test-body-footer'}}

--- a/tests/unit/prop-types/hash-api/any-test.js
+++ b/tests/unit/prop-types/hash-api/any-test.js
@@ -6,7 +6,12 @@ const {Logger} = Ember
 import {afterEach, beforeEach, describe} from 'mocha'
 import sinon from 'sinon'
 
-import {itValidatesTheProperty, spyOnValidateMethods} from 'dummy/tests/helpers/validator'
+import {
+  itSupportsUpdatableOption,
+  itValidatesTheProperty,
+  spyOnValidateMethods
+} from 'dummy/tests/helpers/validator'
+
 import PropTypesMixin, {PropTypes} from 'ember-prop-types/mixins/prop-types'
 
 const requiredDef = {
@@ -1553,4 +1558,6 @@ describe('Unit / validator / PropTypes.any()', function () {
       })
     })
   })
+
+  itSupportsUpdatableOption('any', 1, 'test')
 })

--- a/tests/unit/prop-types/hash-api/array-of-test.js
+++ b/tests/unit/prop-types/hash-api/array-of-test.js
@@ -1,8 +1,10 @@
 /**
  * Unit test for the PropTypes.arrayOf validator
  */
+import {expect} from 'chai'
 import Ember from 'ember'
-import {afterEach, beforeEach, describe} from 'mocha'
+const {Logger} = Ember
+import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
 
 import {itValidatesTheProperty, spyOnValidateMethods} from 'dummy/tests/helpers/validator'
@@ -310,6 +312,69 @@ describe('Unit / validator / PropTypes.arrayOf', function () {
         })
 
         itValidatesTheProperty(ctx, false)
+      })
+    })
+  })
+
+  describe('when updatable', function () {
+    beforeEach(function () {
+      Logger.warn.reset()
+
+      ctx.def = {
+        required: false,
+        type: 'arrayOf',
+        updatable: true
+      }
+
+      const Foo = Ember.Object.extend(PropTypesMixin, {
+        propTypes: {
+          bar: PropTypes.arrayOf(PropTypes.string, {updatable: true})
+        }
+      })
+
+      ctx.instance = Foo.create({bar: ['foo']})
+    })
+
+    describe('when updated', function () {
+      beforeEach(function () {
+        ctx.instance.set('bar', ['foo', 'bar'])
+      })
+
+      it('does not log warning', function () {
+        expect(Logger.warn.called).to.equal(false)
+      })
+    })
+  })
+
+  describe('when not updatable', function () {
+    beforeEach(function () {
+      Logger.warn.reset()
+
+      ctx.def = {
+        required: false,
+        type: 'arrayOf',
+        updatable: false
+      }
+
+      const Foo = Ember.Object.extend(PropTypesMixin, {
+        propTypes: {
+          bar: PropTypes.arrayOf(PropTypes.string, {updatable: false})
+        }
+      })
+
+      ctx.instance = Foo.create({bar: ['foo']})
+    })
+
+    describe('when updated', function () {
+      beforeEach(function () {
+        ctx.instance.set('bar', ['foo', 'bar'])
+      })
+
+      it('logs warning', function () {
+        expect(Logger.warn.called).to.equal(true)
+        expect(Logger.warn).to.have.been.calledWith(
+          `[${ctx.instance.toString()}]: bar should not be updated`
+        )
       })
     })
   })

--- a/tests/unit/prop-types/hash-api/array-test.js
+++ b/tests/unit/prop-types/hash-api/array-test.js
@@ -6,6 +6,7 @@ import {afterEach, beforeEach, describe} from 'mocha'
 import sinon from 'sinon'
 
 import {
+  itSupportsUpdatableOption,
   itValidatesOnUpdate,
   itValidatesTheProperty,
   spyOnValidateMethods
@@ -149,4 +150,6 @@ describe('Unit / validator / PropTypes.array', function () {
       itValidatesOnUpdate(ctx, 'array', 'Expected property bar to be an array')
     })
   })
+
+  itSupportsUpdatableOption('array', [1], [2])
 })

--- a/tests/unit/prop-types/hash-api/bool-test.js
+++ b/tests/unit/prop-types/hash-api/bool-test.js
@@ -7,6 +7,7 @@ import {afterEach, beforeEach, describe} from 'mocha'
 import sinon from 'sinon'
 
 import {
+  itSupportsUpdatableOption,
   itValidatesOnUpdate,
   itValidatesTheProperty,
   spyOnValidateMethods
@@ -252,4 +253,6 @@ describe('Unit / validator / PropTypes.bool', function () {
       itValidatesTheProperty(ctx, false)
     })
   })
+
+  itSupportsUpdatableOption('bool', true, false)
 })

--- a/tests/unit/prop-types/hash-api/element-test.js
+++ b/tests/unit/prop-types/hash-api/element-test.js
@@ -6,6 +6,7 @@ import {afterEach, beforeEach, describe} from 'mocha'
 import sinon from 'sinon'
 
 import {
+  itSupportsUpdatableOption,
   itValidatesOnUpdate,
   itValidatesTheProperty,
   spyOnValidateMethods
@@ -149,4 +150,6 @@ describe('Unit / validator / PropTypes.element', function () {
       itValidatesOnUpdate(ctx, 'element', 'Expected property bar to be an element')
     })
   })
+
+  itSupportsUpdatableOption('element', document.createElement('div'), document.createElement('span'))
 })

--- a/tests/unit/prop-types/hash-api/ember-component-test.js
+++ b/tests/unit/prop-types/hash-api/ember-component-test.js
@@ -5,7 +5,12 @@ import Ember from 'ember'
 import {afterEach, beforeEach, describe} from 'mocha'
 import sinon from 'sinon'
 
-import {itValidatesTheProperty, spyOnValidateMethods} from 'dummy/tests/helpers/validator'
+import {
+  itSupportsUpdatableOption,
+  itValidatesTheProperty,
+  spyOnValidateMethods
+} from 'dummy/tests/helpers/validator'
+
 import PropTypesMixin, {PropTypes} from 'ember-prop-types/mixins/prop-types'
 
 const requiredDef = {
@@ -152,4 +157,6 @@ describe('Unit / validator / PropTypes.EmberComponent', function () {
       itValidatesTheProperty(ctx, false)
     })
   })
+
+  itSupportsUpdatableOption('EmberComponent', component('foo-bar'), component('bar-baz'))
 })

--- a/tests/unit/prop-types/hash-api/ember-object-test.js
+++ b/tests/unit/prop-types/hash-api/ember-object-test.js
@@ -5,7 +5,12 @@ import Ember from 'ember'
 import {afterEach, beforeEach, describe} from 'mocha'
 import sinon from 'sinon'
 
-import {itValidatesTheProperty, spyOnValidateMethods} from 'dummy/tests/helpers/validator'
+import {
+  itSupportsUpdatableOption,
+  itValidatesTheProperty,
+  spyOnValidateMethods
+} from 'dummy/tests/helpers/validator'
+
 import PropTypesMixin, {PropTypes} from 'ember-prop-types/mixins/prop-types'
 
 const requiredDef = {
@@ -135,4 +140,6 @@ describe('Unit / validator / PropTypes.EmberObject', function () {
       itValidatesTheProperty(ctx, false)
     })
   })
+
+  itSupportsUpdatableOption('EmberObject', Ember.Object.create({}), Ember.Object.create({}))
 })

--- a/tests/unit/prop-types/hash-api/func-test.js
+++ b/tests/unit/prop-types/hash-api/func-test.js
@@ -6,6 +6,7 @@ import {afterEach, beforeEach, describe} from 'mocha'
 import sinon from 'sinon'
 
 import {
+  itSupportsUpdatableOption,
   itValidatesOnUpdate,
   itValidatesTheProperty,
   spyOnValidateMethods
@@ -149,4 +150,6 @@ describe('Unit / validator / PropTypes.func', function () {
       itValidatesOnUpdate(ctx, 'func', 'Expected property bar to be a function')
     })
   })
+
+  itSupportsUpdatableOption('func', () => {}, () => {})
 })

--- a/tests/unit/prop-types/hash-api/instance-of-test.js
+++ b/tests/unit/prop-types/hash-api/instance-of-test.js
@@ -1,8 +1,10 @@
 /**
  * Unit test for the PropTypes.instanceOf validator
  */
+import {expect} from 'chai'
 import Ember from 'ember'
-import {afterEach, beforeEach, describe} from 'mocha'
+const {Logger} = Ember
+import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
 
 import {itValidatesTheProperty, spyOnValidateMethods} from 'dummy/tests/helpers/validator'
@@ -102,6 +104,69 @@ describe('Unit / validator / PropTypes.instanceOf', function () {
       })
 
       itValidatesTheProperty(ctx, false)
+    })
+  })
+
+  describe('when updatable', function () {
+    beforeEach(function () {
+      Logger.warn.reset()
+
+      ctx.def = {
+        required: false,
+        type: 'instanceOf',
+        updatable: true
+      }
+
+      const Foo = Ember.Object.extend(PropTypesMixin, {
+        propTypes: {
+          bar: PropTypes.instanceOf(Classy, {updatable: true})
+        }
+      })
+
+      ctx.instance = Foo.create({bar: new Classy()})
+    })
+
+    describe('when updated', function () {
+      beforeEach(function () {
+        ctx.instance.set('bar', new Classy())
+      })
+
+      it('does not log warning', function () {
+        expect(Logger.warn.called).to.equal(false)
+      })
+    })
+  })
+
+  describe('when not updatable', function () {
+    beforeEach(function () {
+      Logger.warn.reset()
+
+      ctx.def = {
+        required: false,
+        type: 'instanceOf',
+        updatable: false
+      }
+
+      const Foo = Ember.Object.extend(PropTypesMixin, {
+        propTypes: {
+          bar: PropTypes.instanceOf(Classy, {updatable: false})
+        }
+      })
+
+      ctx.instance = Foo.create({bar: new Classy()})
+    })
+
+    describe('when updated', function () {
+      beforeEach(function () {
+        ctx.instance.set('bar', new Classy())
+      })
+
+      it('logs warning', function () {
+        expect(Logger.warn.called).to.equal(true)
+        expect(Logger.warn).to.have.been.calledWith(
+          `[${ctx.instance.toString()}]: bar should not be updated`
+        )
+      })
     })
   })
 })

--- a/tests/unit/prop-types/hash-api/null-test.js
+++ b/tests/unit/prop-types/hash-api/null-test.js
@@ -6,6 +6,7 @@ import {afterEach, beforeEach, describe} from 'mocha'
 import sinon from 'sinon'
 
 import {
+  itSupportsUpdatableOption,
   itValidatesOnUpdate,
   itValidatesTheProperty,
   spyOnValidateMethods
@@ -149,4 +150,6 @@ describe('Unit / validator / PropTypes.null', function () {
       itValidatesOnUpdate(ctx, 'null', 'Expected property bar to be null')
     })
   })
+
+  itSupportsUpdatableOption('null', undefined, null)
 })

--- a/tests/unit/prop-types/hash-api/number-test.js
+++ b/tests/unit/prop-types/hash-api/number-test.js
@@ -6,6 +6,7 @@ import {afterEach, beforeEach, describe} from 'mocha'
 import sinon from 'sinon'
 
 import {
+  itSupportsUpdatableOption,
   itValidatesOnUpdate,
   itValidatesTheProperty,
   spyOnValidateMethods
@@ -149,4 +150,6 @@ describe('Unit / validator / PropTypes.number', function () {
       itValidatesOnUpdate(ctx, 'number', 'Expected property bar to be a number')
     })
   })
+
+  itSupportsUpdatableOption('number', 1, 2)
 })

--- a/tests/unit/prop-types/hash-api/object-test.js
+++ b/tests/unit/prop-types/hash-api/object-test.js
@@ -6,6 +6,7 @@ import {afterEach, beforeEach, describe} from 'mocha'
 import sinon from 'sinon'
 
 import {
+  itSupportsUpdatableOption,
   itValidatesOnUpdate,
   itValidatesTheProperty,
   spyOnValidateMethods
@@ -149,4 +150,6 @@ describe('Unit / validator / PropTypes.object', function () {
       itValidatesOnUpdate(ctx, 'object', 'Expected property bar to be an object')
     })
   })
+
+  itSupportsUpdatableOption('object', {foo: 1}, {bar: 2})
 })

--- a/tests/unit/prop-types/hash-api/one-of-test.js
+++ b/tests/unit/prop-types/hash-api/one-of-test.js
@@ -1,8 +1,10 @@
 /**
  * Unit test for the PropTypes.oneOf validator
  */
+import {expect} from 'chai'
 import Ember from 'ember'
-import {afterEach, beforeEach, describe} from 'mocha'
+const {Logger} = Ember
+import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
 
 import {itValidatesTheProperty, spyOnValidateMethods} from 'dummy/tests/helpers/validator'
@@ -132,6 +134,69 @@ describe('Unit / validator / PropTypes.oneOf', function () {
       })
 
       itValidatesTheProperty(ctx, false)
+    })
+  })
+
+  describe('when updatable', function () {
+    beforeEach(function () {
+      Logger.warn.reset()
+
+      ctx.def = {
+        required: false,
+        type: 'oneOf',
+        updatable: true
+      }
+
+      const Foo = Ember.Object.extend(PropTypesMixin, {
+        propTypes: {
+          bar: PropTypes.oneOf(['foo', 'bar'], {updatable: true})
+        }
+      })
+
+      ctx.instance = Foo.create({bar: 'foo'})
+    })
+
+    describe('when updated', function () {
+      beforeEach(function () {
+        ctx.instance.set('bar', 'bar')
+      })
+
+      it('does not log warning', function () {
+        expect(Logger.warn.called).to.equal(false)
+      })
+    })
+  })
+
+  describe('when not updatable', function () {
+    beforeEach(function () {
+      Logger.warn.reset()
+
+      ctx.def = {
+        required: false,
+        type: 'oneOf',
+        updatable: false
+      }
+
+      const Foo = Ember.Object.extend(PropTypesMixin, {
+        propTypes: {
+          bar: PropTypes.oneOf(['foo', 'bar'], {updatable: false})
+        }
+      })
+
+      ctx.instance = Foo.create({bar: 'foo'})
+    })
+
+    describe('when updated', function () {
+      beforeEach(function () {
+        ctx.instance.set('bar', 'bar')
+      })
+
+      it('logs warning', function () {
+        expect(Logger.warn.called).to.equal(true)
+        expect(Logger.warn).to.have.been.calledWith(
+          `[${ctx.instance.toString()}]: bar should not be updated`
+        )
+      })
     })
   })
 })

--- a/tests/unit/prop-types/hash-api/one-of-type-test.js
+++ b/tests/unit/prop-types/hash-api/one-of-type-test.js
@@ -1,8 +1,10 @@
 /**
  * Unit test for the PropTypes.oneOfType validator
  */
+import {expect} from 'chai'
 import Ember from 'ember'
-import {afterEach, beforeEach, describe} from 'mocha'
+const {Logger} = Ember
+import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
 
 import {itValidatesTheProperty, spyOnValidateMethods} from 'dummy/tests/helpers/validator'
@@ -152,6 +154,69 @@ describe('Unit / validator / PropTypes.oneOfType', function () {
       })
 
       itValidatesTheProperty(ctx, false)
+    })
+  })
+
+  describe('when updatable', function () {
+    beforeEach(function () {
+      Logger.warn.reset()
+
+      ctx.def = {
+        required: false,
+        type: 'oneOfType',
+        updatable: true
+      }
+
+      const Foo = Ember.Object.extend(PropTypesMixin, {
+        propTypes: {
+          bar: PropTypes.oneOfType([PropTypes.null, PropTypes.string], {updatable: true})
+        }
+      })
+
+      ctx.instance = Foo.create({bar: null})
+    })
+
+    describe('when updated', function () {
+      beforeEach(function () {
+        ctx.instance.set('bar', 'test')
+      })
+
+      it('does not log warning', function () {
+        expect(Logger.warn.called).to.equal(false)
+      })
+    })
+  })
+
+  describe('when not updatable', function () {
+    beforeEach(function () {
+      Logger.warn.reset()
+
+      ctx.def = {
+        required: false,
+        type: 'oneOfType',
+        updatable: false
+      }
+
+      const Foo = Ember.Object.extend(PropTypesMixin, {
+        propTypes: {
+          bar: PropTypes.oneOfType([PropTypes.null, PropTypes.string], {updatable: false})
+        }
+      })
+
+      ctx.instance = Foo.create({bar: null})
+    })
+
+    describe('when updated', function () {
+      beforeEach(function () {
+        ctx.instance.set('bar', 'test')
+      })
+
+      it('logs warning', function () {
+        expect(Logger.warn.called).to.equal(true)
+        expect(Logger.warn).to.have.been.calledWith(
+          `[${ctx.instance.toString()}]: bar should not be updated`
+        )
+      })
     })
   })
 })

--- a/tests/unit/prop-types/hash-api/shape-test.js
+++ b/tests/unit/prop-types/hash-api/shape-test.js
@@ -1,8 +1,10 @@
 /**
  * Unit test for the PropTypes.shape validator
  */
+import {expect} from 'chai'
 import Ember from 'ember'
-import {afterEach, beforeEach, describe} from 'mocha'
+const {Logger} = Ember
+import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
 
 import {itValidatesTheProperty, spyOnValidateMethods} from 'dummy/tests/helpers/validator'
@@ -439,6 +441,69 @@ describe('Unit / validator / PropTypes.shape', function () {
       })
 
       itValidatesTheProperty(ctx, false)
+    })
+  })
+
+  describe('when updatable', function () {
+    beforeEach(function () {
+      Logger.warn.reset()
+
+      ctx.def = {
+        required: false,
+        type: 'shape',
+        updatable: true
+      }
+
+      const Foo = Ember.Object.extend(PropTypesMixin, {
+        propTypes: {
+          bar: PropTypes.shape({foo: PropTypes.string}, {updatable: true})
+        }
+      })
+
+      ctx.instance = Foo.create({bar: {foo: 'bar'}})
+    })
+
+    describe('when updated', function () {
+      beforeEach(function () {
+        ctx.instance.set('bar', {foo: 'baz'})
+      })
+
+      it('does not log warning', function () {
+        expect(Logger.warn.called).to.equal(false)
+      })
+    })
+  })
+
+  describe('when not updatable', function () {
+    beforeEach(function () {
+      Logger.warn.reset()
+
+      ctx.def = {
+        required: false,
+        type: 'shape',
+        updatable: false
+      }
+
+      const Foo = Ember.Object.extend(PropTypesMixin, {
+        propTypes: {
+          bar: PropTypes.shape({foo: PropTypes.string}, {updatable: false})
+        }
+      })
+
+      ctx.instance = Foo.create({bar: {foo: 'bar'}})
+    })
+
+    describe('when updated', function () {
+      beforeEach(function () {
+        ctx.instance.set('bar', {foo: 'baz'})
+      })
+
+      it('logs warning', function () {
+        expect(Logger.warn.called).to.equal(true)
+        expect(Logger.warn).to.have.been.calledWith(
+          `[${ctx.instance.toString()}]: bar should not be updated`
+        )
+      })
     })
   })
 })

--- a/tests/unit/prop-types/hash-api/string-test.js
+++ b/tests/unit/prop-types/hash-api/string-test.js
@@ -6,6 +6,7 @@ import {afterEach, beforeEach, describe} from 'mocha'
 import sinon from 'sinon'
 
 import {
+  itSupportsUpdatableOption,
   itValidatesOnUpdate,
   itValidatesTheProperty,
   spyOnValidateMethods
@@ -149,4 +150,6 @@ describe('Unit / validator / PropTypes.string', function () {
       itValidatesOnUpdate(ctx, 'string', 'Expected property bar to be a string')
     })
   })
+
+  itSupportsUpdatableOption('string', 'foo', 'bar')
 })

--- a/tests/unit/prop-types/hash-api/symbol-test.js
+++ b/tests/unit/prop-types/hash-api/symbol-test.js
@@ -6,6 +6,7 @@ import {afterEach, beforeEach, describe} from 'mocha'
 import sinon from 'sinon'
 
 import {
+  itSupportsUpdatableOption,
   itValidatesOnUpdate,
   itValidatesTheProperty,
   spyOnValidateMethods
@@ -149,4 +150,6 @@ describe('Unit / validator / PropTypes.symbol', function () {
       itValidatesOnUpdate(ctx, 'symbol', 'Expected property bar to be a symbol')
     })
   })
+
+  itSupportsUpdatableOption('symbol', Symbol(), Symbol())
 })


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

Resolves #82

# CHANGELOG

* **Added** new `updatable` option to all types to flag components that shouldn't allow updates. By default all properties will allow updates so specifying `updatable: true` isn't necessary.
