### PR TITLE
Fix EmberComponent prop type for Ember 2.11

### DIFF
--- a/addon/utils/validators/ember-component.js
+++ b/addon/utils/validators/ember-component.js
@@ -12,7 +12,10 @@ export default function (ctx, name, value, def, logErrors, throwErrors) {
 
   const valid = isObject && Object.keys(value).some((key) => {
     // NOTE: this is based on internal API and thus could break without warning.
-    return key.indexOf('COMPONENT_CELL') === 0
+    return (
+      key.indexOf('COMPONENT_CELL') === 0 || // Pre Glimmer 2
+      key.indexOf('COMPONENT DEFINITION') === 0 // Glimmer 2
+    )
   })
 
   if (!valid && logErrors) {


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** `EmberComponent` prop type to work properly with Glimmer 2.
