### PR TITLE
link to own docs page

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ ember install ember-prop-types
 
 ## Usage
 
+**[Full Docs](http://ciena-blueplanet.github.io/ember-prop-types/)**
+
+## Examples
+
 ### Better Components
 
 Below is an example of a component that uses the property mixin provided by this


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

I almost completely missed that the docs site existed 😃 

# CHANGELOG

- Added link to own docs page
