### PR TITLE
Fixing a regression in getDefaultProps execution ordering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,8 @@
 /connect.lock
 /coverage/*
 /libpeerconnection.log
+/typings/*
 npm-debug.log
 testem.log
+.vscodeignore
+jsconfig.json

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.5.0",
-    "ember-cli": "^2.12.0",
+    "ember-cli": "~2.11.0",
     "ember-cli-app-version": "^2.0.1",
     "ember-cli-chai": "0.3.2",
     "ember-cli-code-coverage": "0.3.12",


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

#118 broke the hierarchy of getDefaultProps - previously parent layers properties were accessible to the children.  Also made the application of the hierarchy more robust by allowing children to override parent defaults while not overriding properties set explicitly on the target.

# CHANGELOG

- Fixed a regression in the execution order of getDefaultProps introduced in #118 
