### PR TITLE
fixed error with nameOfType.  typedef may not return a function string.

### DIFF
--- a/addon/utils/validators/instance-of.js
+++ b/addon/utils/validators/instance-of.js
@@ -10,7 +10,9 @@ export default function (ctx, name, value, def, logErrors, throwErrors) {
   const valid = value instanceof type
 
   if (!valid && logErrors) {
-    const nameOfType = type.toString().match(/function (\w*)/)[1]
+    const typeString = type.toString()
+    const nameOfTypeMatch = typeString.match(/function (\w*)/)
+    const nameOfType = nameOfTypeMatch ? nameOfTypeMatch[1] : typeString
     logger.warn(
       ctx,
       `Expected property ${name} to be an instance of ${nameOfType} but instead got: ${typeOf(value)}`,


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
 fixed error with nameOfType if typedef does not return a function string