### PR TITLE
Update string validation to support Ember SafeString objects.

### DIFF
--- a/addon/utils/validators/string.js
+++ b/addon/utils/validators/string.js
@@ -8,7 +8,7 @@ const {typeOf} = Ember
 import logger from '../logger'
 
 export default function (ctx, name, value, def, logErrors, throwErrors) {
-  const valid = typeOf(value) === 'string'
+  const valid = typeOf(value) === 'string' || Ember.String.isHTMLSafe(value)
 
   if (!valid && logErrors) {
     logger.warn(ctx, `Expected property ${name} to be a string but instead got: ${typeOf(value)}`, throwErrors)

--- a/tests/unit/prop-types/hash-api/string-test.js
+++ b/tests/unit/prop-types/hash-api/string-test.js
@@ -56,6 +56,15 @@ describe('Unit / validator / PropTypes.string', function () {
       itValidatesOnUpdate(ctx, 'string', 'Expected property bar to be a string')
     })
 
+    describe('when initialized with a SafeString object value', function () {
+      beforeEach(function () {
+        ctx.instance = Foo.create({bar: Ember.String.htmlSafe('baz')})
+      })
+
+      itValidatesTheProperty(ctx, false)
+      itValidatesOnUpdate(ctx, 'string', 'Expected property bar to be a string')
+    })
+
     describe('when initialized with number value', function () {
       beforeEach(function () {
         ctx.instance = Foo.create({bar: 1})
@@ -94,6 +103,15 @@ describe('Unit / validator / PropTypes.string', function () {
       itValidatesOnUpdate(ctx, 'string', 'Expected property bar to be a string')
     })
 
+    describe('when initialized with a SafeString object value', function () {
+      beforeEach(function () {
+        ctx.instance = Foo.create({bar: Ember.String.htmlSafe('baz')})
+      })
+
+      itValidatesTheProperty(ctx, false)
+      itValidatesOnUpdate(ctx, 'string', 'Expected property bar to be a string')
+    })
+
     describe('when initialized with number value', function () {
       beforeEach(function () {
         ctx.instance = Foo.create({bar: 1})
@@ -126,6 +144,15 @@ describe('Unit / validator / PropTypes.string', function () {
     describe('when initialized with string value', function () {
       beforeEach(function () {
         ctx.instance = Foo.create({bar: 'baz'})
+      })
+
+      itValidatesTheProperty(ctx, false)
+      itValidatesOnUpdate(ctx, 'string', 'Expected property bar to be a string')
+    })
+
+    describe('when initialized with a SafeString object value', function () {
+      beforeEach(function () {
+        ctx.instance = Foo.create({bar: Ember.String.htmlSafe('baz')})
       })
 
       itValidatesTheProperty(ctx, false)

--- a/tests/unit/prop-types/property-api/string-test.js
+++ b/tests/unit/prop-types/property-api/string-test.js
@@ -56,6 +56,15 @@ describe('Unit / validator / PropTypes.string', function () {
       itValidatesOnUpdate(ctx, 'string', 'Expected property bar to be a string')
     })
 
+    describe('when initialized with a SafeString object value', function () {
+      beforeEach(function () {
+        ctx.instance = Foo.create({bar: Ember.String.htmlSafe('baz')})
+      })
+
+      itValidatesTheProperty(ctx, false)
+      itValidatesOnUpdate(ctx, 'string', 'Expected property bar to be a string')
+    })
+
     describe('when initialized with number value', function () {
       beforeEach(function () {
         ctx.instance = Foo.create({bar: 1})
@@ -88,6 +97,15 @@ describe('Unit / validator / PropTypes.string', function () {
     describe('when initialized with string value', function () {
       beforeEach(function () {
         ctx.instance = Foo.create({bar: 'baz'})
+      })
+
+      itValidatesTheProperty(ctx, false)
+      itValidatesOnUpdate(ctx, 'string', 'Expected property bar to be a string')
+    })
+
+    describe('when initialized with a SafeString object value', function () {
+      beforeEach(function () {
+        ctx.instance = Foo.create({bar: Ember.String.htmlSafe('baz')})
       })
 
       itValidatesTheProperty(ctx, false)


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
Update string validation to support Ember SafeString objects. Fixes #128.
