### PR TITLE
Upgrade ember-get-config

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.8",
-    "ember-get-config": "0.2.1",
+    "ember-get-config": "^0.2.2",
     "npm-install-security-check": "^1.0.0"
   },
   "ember-addon": {


### PR DESCRIPTION
It's not clear whether locking to a specific `ember-get-config` version was intentional here, but we'd like to pick up [this change](https://github.com/null-null-null/ember-get-config/commit/ee7ebf759f28149444f7205b7533e903b1558b2b) to eliminate some noise in our builds for apps involving engines.

**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

Update `ember-get-config` and allow the version to float.
