### PR TITLE
Closes ciena-blueplanet/ember-prop-types#139

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,10 @@
 {
   "name": "ember-prop-types",
   "dependencies": {
-    "prism": "^1.5.1"
+    "prism": "^1.5.1",
+    "ember": "components/ember#lts-2-4"
+  },
+  "resolutions": {
+    "ember": "lts-2-4"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -1,10 +1,6 @@
 {
   "name": "ember-prop-types",
   "dependencies": {
-    "prism": "^1.5.1",
-    "ember": "components/ember#lts-2-4"
-  },
-  "resolutions": {
-    "ember": "lts-2-4"
+    "prism": "^1.5.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "ember-sinon": "0.7.0",
     "ember-source": "~2.12.0",
     "ember-spread": "^1.0.0",
+    "ember-string-ishtmlsafe-polyfill": "^1.1.0",
     "ember-test-utils": "^4.0.0",
     "loader.js": "^4.2.3",
     "sinon-chai": "^2.8.0"


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* Install `ember-string-ishtmlsafe-polyfill` to address #139 