### PR TITLE
Fallback for Object.assign

### DIFF
--- a/addon/mixins/prop-types.js
+++ b/addon/mixins/prop-types.js
@@ -2,10 +2,12 @@
  * The PropTypesMixin definition
  */
 import Ember from 'ember'
-const {Mixin, get, getWithDefault, typeOf} = Ember
+const {Mixin, get, getWithDefault, typeOf, assign, merge} = Ember
 import config from 'ember-get-config'
 
 import PropTypes, {getDef, logger, validators} from '../utils/prop-types'
+
+const assign = Object.assign || assign || merge
 
 export const settings = {
   requireComponentPropTypes: getWithDefault(
@@ -131,7 +133,7 @@ export default Mixin.create({
       })
 
       // Record the properties that were defaulted
-      Object.assign(defaultedProps, defaultProps)
+      assign(defaultedProps, defaultProps)
 
       // Apply the defaults for this layer of the hierarchy immediately
       // @sglanzer 2017-05-29 PR #118 delayed the execution of the setProperties

--- a/addon/utils/validators/index.js
+++ b/addon/utils/validators/index.js
@@ -1,4 +1,5 @@
 import Ember from 'ember' // eslint-disable-line
+const {assign, merge} = Ember
 
 import any from './any'
 import array from './array'
@@ -19,7 +20,7 @@ import shape from './shape'
 import string from './string'
 import symbol from './symbol'
 
-const assign = Object.assign || Ember.assign || Ember.merge // eslint-disable-line
+const assign = Object.assign || assign || merge
 
 const validators = {
   any,


### PR DESCRIPTION
Similar commit: https://github.com/ciena-blueplanet/ember-prop-types/commit/2bb0d5ba830a18a9748329ad584ca64cfbe13c55

**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

Fallback for Object.assign in order to support IE 11
