### PR TITLE
Object.assign fallback (v2)

### DIFF
--- a/addon/mixins/prop-types.js
+++ b/addon/mixins/prop-types.js
@@ -7,6 +7,8 @@ import config from 'ember-get-config'
 
 import PropTypes, {getDef, logger, validators} from '../utils/prop-types'
 
+const assign = Object.assign || Ember.assign || Ember.merge // eslint-disable-line
+
 export const settings = {
   requireComponentPropTypes: getWithDefault(
     config, 'ember-prop-types.requireComponentPropTypes', false
@@ -131,7 +133,7 @@ export default Mixin.create({
       })
 
       // Record the properties that were defaulted
-      Object.assign(defaultedProps, defaultProps)
+      assign(defaultedProps, defaultProps)
 
       // Apply the defaults for this layer of the hierarchy immediately
       // @sglanzer 2017-05-29 PR #118 delayed the execution of the setProperties

--- a/addon/mixins/prop-types.js
+++ b/addon/mixins/prop-types.js
@@ -2,12 +2,12 @@
  * The PropTypesMixin definition
  */
 import Ember from 'ember'
-const {Mixin, get, getWithDefault, typeOf} = Ember
+const {Mixin, assign, get, getWithDefault, merge, typeOf} = Ember
 import config from 'ember-get-config'
 
 import PropTypes, {getDef, logger, validators} from '../utils/prop-types'
 
-const assign = Object.assign || Ember.assign || Ember.merge // eslint-disable-line
+const objectAssign = Object.assign || assign || merge
 
 export const settings = {
   requireComponentPropTypes: getWithDefault(
@@ -133,7 +133,7 @@ export default Mixin.create({
       })
 
       // Record the properties that were defaulted
-      assign(defaultedProps, defaultProps)
+      objectAssign(defaultedProps, defaultProps)
 
       // Apply the defaults for this layer of the hierarchy immediately
       // @sglanzer 2017-05-29 PR #118 delayed the execution of the setProperties

--- a/addon/utils/validators/index.js
+++ b/addon/utils/validators/index.js
@@ -1,5 +1,7 @@
 import Ember from 'ember' // eslint-disable-line
 
+const {assign, merge} = Ember
+
 import any from './any'
 import array from './array'
 import arrayOf from './array-of'
@@ -19,7 +21,7 @@ import shape from './shape'
 import string from './string'
 import symbol from './symbol'
 
-const assign = Object.assign || Ember.assign || Ember.merge // eslint-disable-line
+const objectAssign = Object.assign || assign || merge
 
 const validators = {
   any,
@@ -39,7 +41,7 @@ const validators = {
   symbol
 }
 
-assign(validators, {
+objectAssign(validators, {
   arrayOf: arrayOf.bind(this, validators),
   oneOfType: oneOfType.bind(this, validators),
   shape: shape.bind(this, validators)


### PR DESCRIPTION
New version of #142, more or less.

**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

- Adds a fallback for Object.assign for browsers that don't support it (i.e. IE).
