### PR TITLE
Add support for iface type

### DIFF
--- a/addon/utils/prop-types.js
+++ b/addon/utils/prop-types.js
@@ -209,6 +209,36 @@ PropTypes.shape = function (typeDefs, options) {
   return type
 }
 
+PropTypes.iface = function (typeDefs, options) {
+  const type = generateType('iface')
+
+  if (typeOf(typeDefs) === 'object') {
+    Object.keys(typeDefs)
+      .forEach((key) => {
+        typeDefs[key] = getDef(typeDefs[key])
+      })
+  }
+
+  type.typeDefs = typeDefs
+
+  if (typeOf(options) !== 'object') {
+    type.isRequired.typeDefs = type.typeDefs
+    return type
+  }
+
+  delete type.isRequired
+
+  if ('required' in options) {
+    type.required = options.required
+  }
+
+  if (options.updatable === false) {
+    type.updatable = false
+  }
+
+  return type
+}
+
 export default PropTypes
 export {validators}
 export {logger}

--- a/addon/utils/validators/iface.js
+++ b/addon/utils/validators/iface.js
@@ -1,0 +1,52 @@
+/**
+ * The PropTypes.iface validator
+ */
+
+import Ember from 'ember'
+const {get, typeOf} = Ember
+
+import logger from '../logger'
+
+export default function (validators, ctx, name, value, def, logErrors, throwErrors) {
+  const typeDefs = def.typeDefs
+  let msg = `Expected property ${name} to match given interface`
+  let iface
+  try {
+    iface = JSON.stringify(value, null, ' ')
+    msg = `${msg}, but instead got value ${iface}`
+  } catch (e) {}
+
+  if (typeOf(typeDefs) !== 'object') {
+    logger.warn(ctx, 'PropTypes.iface() requires a plain object to be be passed in as an argument', throwErrors)
+    return false
+  }
+
+  if (typeOf(value) !== 'object') {
+    logger.warn(ctx, msg, throwErrors)
+    return false
+  }
+
+  let valid = Object.keys(typeDefs).every((key) => {
+    const typeDef = typeDefs[key]
+
+    const objectValue = get(value, key)
+    if (objectValue === undefined) {
+      if (!typeDef.required) {
+        return true
+      } else {
+        if (logErrors) {
+          logger.warn(ctx, `Property ${name} is missing required property ${key}`, throwErrors)
+        }
+        return false
+      }
+    }
+
+    return validators[typeDef.type](ctx, `${name}.${key}`, objectValue, typeDef, logErrors, throwErrors)
+  })
+
+  if (!valid && logErrors) {
+    logger.warn(ctx, msg, throwErrors)
+  }
+
+  return valid
+}

--- a/addon/utils/validators/iface.js
+++ b/addon/utils/validators/iface.js
@@ -21,7 +21,8 @@ export default function (validators, ctx, name, value, def, logErrors, throwErro
     return false
   }
 
-  if (typeOf(value) !== 'object') {
+  // allow POJOs as well as Ember Object instances for greater flexibility
+  if (typeOf(value) !== 'object' && typeOf(value) !== 'instance') {
     logger.warn(ctx, msg, throwErrors)
     return false
   }

--- a/addon/utils/validators/iface.js
+++ b/addon/utils/validators/iface.js
@@ -7,6 +7,7 @@ const {get, typeOf} = Ember
 
 import logger from '../logger'
 
+/* eslint-disable complexity */
 export default function (validators, ctx, name, value, def, logErrors, throwErrors) {
   const typeDefs = def.typeDefs
   let msg = `Expected property ${name} to match given interface`

--- a/addon/utils/validators/index.js
+++ b/addon/utils/validators/index.js
@@ -9,6 +9,7 @@ import element from './element'
 import emberComponent from './ember-component'
 import emberObject from './ember-object'
 import func from './func'
+import iface from './iface'
 import instanceOf from './instance-of'
 import nullFn from './null'
 import number from './number'
@@ -43,6 +44,7 @@ const validators = {
 
 objectAssign(validators, {
   arrayOf: arrayOf.bind(this, validators),
+  iface: iface.bind(this, validators),
   oneOfType: oneOfType.bind(this, validators),
   shape: shape.bind(this, validators)
 })


### PR DESCRIPTION
# Overview

## Summary
Loosely based on https://github.com/ciena-blueplanet/ember-prop-types/issues/116
We use `iface` in our project, it's really similar to `shape`, the difference is that only specified props are checked.

Here's an example:
```
propTypes: {
  dog: PropTypes.iface({
    bark: PropTypes.function.isRequired,
    color: PropTypes.string
  }).isRequired
},
```
Then you can pass:
```
dog: Ember.Object.extend({
  bark() {
    console.log('woof woof')
  }
}).create()
```
or
```
dog: Ember.Object.extend({
  bark() {
    console.log('ruff ruff')
  },
  color: 'black',
  breed: 'affenpinscher'
}).create()
```
Both are accepted.

## Checklist
If there will be interest in this PR, I can go over the list below and update documentation and provide some tests.

* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have evaluated if the _README.md_ documentation needs to be updated
* [ ] I have evaluated if the _/tests/dummy/_ app needs to be modified
* [ ] I have evaluated if DocBlock headers needed to be added or updated
* [x] I have verified that lint and tests pass locally with my changes

# Semver

**This project uses [semver](http://semver.org), please check the scope of this PR:**

- [ ] #none#
- [ ] #patch#
- [x] #minor#
- [ ] #major#

# CHANGELOG

Support for `iface` type which is checking provided props similar to `shape` type but the missing props are tolerated.